### PR TITLE
feat: add support for encoding and decoding query params 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ version = "0.1.0"
 [dependencies]
 error-chain = "0.11.0"
 http = "0.1"
+percent-encoding = "1.0.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+serde_qs = "0.3.0"
 
 [dependencies.ordermap]
 features = ["serde-1"]

--- a/rocket/Cargo.toml
+++ b/rocket/Cargo.toml
@@ -18,6 +18,7 @@ rocket = "0.3"
 rocket_contrib = "0.3"
 serde = "1.0"
 serde_json = "1.0"
+serde_qs = "0.3.0"
 
 [dependencies.json-api]
 path = "../"

--- a/rocket/src/lib.rs
+++ b/rocket/src/lib.rs
@@ -2,9 +2,12 @@ extern crate json_api;
 extern crate rocket;
 extern crate serde;
 extern crate serde_json;
+extern crate serde_qs;
 
 mod error;
+mod query;
 mod respond;
 
-pub use self::respond::{Collection, Created, Member};
 pub use self::error::ErrorHandler;
+pub use self::query::*;
+pub use self::respond::*;

--- a/rocket/src/query.rs
+++ b/rocket/src/query.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug, Formatter};
+
 use json_api::Error;
 use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
 use json_api::value::{Set, Value};
@@ -7,7 +9,7 @@ use rocket::http::Status;
 use rocket::Outcome;
 use rocket::request::{self, FromRequest, Request};
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Query {
     inner: JsonApiQuery,
 }
@@ -38,6 +40,12 @@ impl Query {
 
     pub fn sort(&self) -> Option<&Sort> {
         self.inner.sort.as_ref()
+    }
+}
+
+impl Debug for Query {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        Debug::fmt(&self.inner, fmtr)
     }
 }
 

--- a/rocket/src/query.rs
+++ b/rocket/src/query.rs
@@ -1,0 +1,58 @@
+use json_api::Error;
+use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
+use json_api::value::{Set, Value};
+use json_api::value::map::Iter as MapIter;
+use json_api::value::set::Iter as SetIter;
+use rocket::http::Status;
+use rocket::Outcome;
+use rocket::request::{self, FromRequest, Request};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Query {
+    inner: JsonApiQuery,
+}
+
+impl Query {
+    /// Consumes the [`Query`] wrapper and returns the wrapped value.
+    ///
+    /// [`Query`]: ./struct.Query.html
+    pub fn into_inner(self) -> JsonApiQuery {
+        self.inner
+    }
+
+    pub fn fields(&self) -> MapIter<Set> {
+        self.inner.fields.iter()
+    }
+
+    pub fn filter(&self) -> MapIter<Value> {
+        self.inner.filter.iter()
+    }
+
+    pub fn include(&self) -> SetIter {
+        self.inner.include.iter()
+    }
+
+    pub fn page(&self) -> Option<Page> {
+        self.inner.page
+    }
+
+    pub fn sort(&self) -> Option<&Sort> {
+        self.inner.sort.as_ref()
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Query {
+    type Error = Error;
+
+    fn from_request(req: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
+        let data = req.uri().query();
+        let result = data.map(query::from_str)
+            .unwrap_or_else(|| Ok(Default::default()))
+            .map(|inner| Query { inner });
+
+        match result {
+            Ok(params) => Outcome::Success(params),
+            Err(e) => Outcome::Failure((Status::BadRequest, e)),
+        }
+    }
+}

--- a/rocket/src/query.rs
+++ b/rocket/src/query.rs
@@ -1,10 +1,8 @@
 use std::fmt::{self, Debug, Formatter};
 
 use json_api::Error;
-use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
-use json_api::value::{Set, Value};
-use json_api::value::map::Iter as MapIter;
-use json_api::value::set::Iter as SetIter;
+use json_api::query::{self, Page, Path, Query as JsonApiQuery, Sort};
+use json_api::value::{map, set, Key, Set, Value};
 use rocket::http::Status;
 use rocket::Outcome;
 use rocket::request::{self, FromRequest, Request};
@@ -22,15 +20,15 @@ impl Query {
         self.inner
     }
 
-    pub fn fields(&self) -> MapIter<Set> {
+    pub fn fields(&self) -> map::Iter<Set<Key>> {
         self.inner.fields.iter()
     }
 
-    pub fn filter(&self) -> MapIter<Value> {
+    pub fn filter(&self) -> map::Iter<Value> {
         self.inner.filter.iter()
     }
 
-    pub fn include(&self) -> SetIter {
+    pub fn include(&self) -> set::Iter<Path> {
         self.inner.include.iter()
     }
 
@@ -38,8 +36,8 @@ impl Query {
         self.inner.page
     }
 
-    pub fn sort(&self) -> Option<&Sort> {
-        self.inner.sort.as_ref()
+    pub fn sort(&self) -> set::Iter<Sort> {
+        self.inner.sort.iter()
     }
 }
 

--- a/rocket/src/query.rs
+++ b/rocket/src/query.rs
@@ -21,11 +21,11 @@ impl Query {
         self.inner
     }
 
-    pub fn fields(&self) -> map::Iter<Set<Key>> {
+    pub fn fields(&self) -> map::Iter<Key, Set<Key>> {
         self.inner.fields.iter()
     }
 
-    pub fn filter(&self) -> map::Iter<Value> {
+    pub fn filter(&self) -> map::Iter<Path, Value> {
         self.inner.filter.iter()
     }
 

--- a/rocket/src/query.rs
+++ b/rocket/src/query.rs
@@ -1,8 +1,9 @@
 use std::fmt::{self, Debug, Formatter};
 
 use json_api::Error;
-use json_api::query::{self, Page, Path, Query as JsonApiQuery, Sort};
-use json_api::value::{map, set, Key, Set, Value};
+use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
+use json_api::value::{map, set, Set, Value};
+use json_api::value::key::{Key, Path};
 use rocket::http::Status;
 use rocket::Outcome;
 use rocket::request::{self, FromRequest, Request};

--- a/rocket/src/respond.rs
+++ b/rocket/src/respond.rs
@@ -138,7 +138,7 @@ impl<T: Resource> Responder<'static> for Member<T> {
     }
 }
 
-pub fn with_body<T>(value: T) -> Result<Response<'static>, Status>
+pub(crate) fn with_body<T>(value: T) -> Result<Response<'static>, Status>
 where
     T: Serialize,
 {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,4 @@
+use std::iter::FromIterator;
 use std::mem;
 
 use error::Error;
@@ -24,8 +25,9 @@ pub fn required<T>(name: &str, value: &mut Option<T>) -> Result<T, Error> {
     mem::replace(value, None).ok_or_else(|| Error::missing_field(name))
 }
 
-pub fn vec<F, T, U>(data: &mut Vec<T>, f: F) -> Result<Vec<U>, Error>
+pub fn iter<F, T, U, C>(data: &mut Vec<T>, f: F) -> Result<C, Error>
 where
+    C: FromIterator<U>,
     F: Fn(T) -> Result<U, Error>,
 {
     data.drain(..).map(f).collect()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,5 +1,7 @@
 use std::iter::FromIterator;
 use std::mem;
+use std::hash::Hash;
+use std::str::FromStr;
 
 use error::Error;
 use value::Map;
@@ -8,9 +10,10 @@ pub fn default<T: Default>(value: &mut Option<T>) -> T {
     mem::replace(value, None).unwrap_or_default()
 }
 
-pub fn map<F, T, U>(data: &mut Vec<(String, T)>, f: F) -> Result<Map<U>, Error>
+pub fn map<F, K, T, U>(data: &mut Vec<(String, T)>, f: F) -> Result<Map<K, U>, Error>
 where
     F: Fn(T) -> Result<U, Error>,
+    K: Eq + FromStr<Err = Error> + Hash,
 {
     data.drain(..)
         .map(|(key, value)| Ok((key.parse()?, f(value)?)))

--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -1,6 +1,6 @@
 use builder;
 use doc::Link;
-use value::{Map, StatusCode, Value};
+use value::{Key, Map, StatusCode, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -12,9 +12,9 @@ pub struct Error {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub links: Map<Link>,
+    pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<Source>,
     #[serde(skip_serializing_if = "Option::is_none", with = "serde_status")]

--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -9,7 +9,7 @@ pub struct Identifier {
     #[serde(rename = "type")]
     pub kind: Key,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/link.rs
+++ b/src/doc/link.rs
@@ -8,12 +8,12 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 use builder;
 use error::Error;
-use value::{Map, Value};
+use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Link {
     pub href: Uri,
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     /// Private field for backwards compatibility.
     _ext: (),
 }

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -57,7 +57,7 @@ pub struct DocumentBuilder<T: PrimaryData> {
 impl<T: PrimaryData> DocumentBuilder<T> {
     pub fn finalize(&mut self) -> Result<Document<T>, ::error::Error> {
         let data = builder::required("data", &mut self.data)?;
-        let included = builder::vec(&mut self.included, Ok)?;
+        let included = builder::iter(&mut self.included, Ok)?;
         let jsonapi = builder::default(&mut self.jsonapi);
         let links = builder::map(&mut self.links, Ok)?;
         let meta = builder::map(&mut self.meta, Ok)?;
@@ -152,7 +152,7 @@ pub struct ErrorDocumentBuilder {
 
 impl ErrorDocumentBuilder {
     pub fn finalize(&mut self) -> Result<ErrorDocument, ::error::Error> {
-        let errors = builder::vec(&mut self.errors, Ok)?;
+        let errors = builder::iter(&mut self.errors, Ok)?;
         let jsonapi = builder::default(&mut self.jsonapi);
         let links = builder::map(&mut self.links, Ok)?;
         let meta = builder::map(&mut self.meta, Ok)?;

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -11,7 +11,7 @@ use serde::ser::Serialize;
 
 use builder;
 use sealed::Sealed;
-use value::{Map, Value};
+use value::{Key, Map, Value};
 
 pub use self::error::Error;
 pub use self::ident::Identifier;
@@ -31,9 +31,9 @@ pub struct Document<T: PrimaryData> {
     #[serde(default)]
     pub jsonapi: JsonApi,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub links: Map<Link>,
+    pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),
@@ -127,9 +127,9 @@ pub struct ErrorDocument {
     #[serde(default)]
     pub jsonapi: JsonApi,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub links: Map<Link>,
+    pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/object.rs
+++ b/src/doc/object.rs
@@ -7,16 +7,16 @@ use value::{Key, Map, Value};
 #[serde(deny_unknown_fields)]
 pub struct Object {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub attributes: Map<Value>,
+    pub attributes: Map<Key, Value>,
     pub id: String,
     #[serde(rename = "type")]
     pub kind: Key,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub links: Map<Link>,
+    pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub relationships: Map<Relationship>,
+    pub relationships: Map<Key, Relationship>,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/relationship.rs
+++ b/src/doc/relationship.rs
@@ -1,16 +1,16 @@
 use builder;
 use doc::{Data, Identifier, Link};
 use error::Error;
-use value::{Map, Value};
+use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Relationship {
     pub data: Data<Identifier>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub links: Map<Link>,
+    pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/specification.rs
+++ b/src/doc/specification.rs
@@ -51,7 +51,7 @@ impl JsonApiBuilder {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Version {
     /// Version 1.0
     V1,

--- a/src/doc/specification.rs
+++ b/src/doc/specification.rs
@@ -6,13 +6,13 @@ use serde::ser::{Serialize, Serializer};
 
 use builder;
 use error::Error;
-use value::{Map, Value};
+use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonApi {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Value>,
+    pub meta: Map<Key, Value>,
     pub version: Version,
     #[serde(skip)]
     _ext: (),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
 use std::fmt::Display;
+use std::str::Utf8Error;
 
 use http::status::InvalidStatusCode as InvalidStatusCodeError;
 use http::uri::InvalidUri as InvalidUriError;
 use serde_json::Error as JsonError;
+use serde_qs::Error as QueryError;
 use serde::de;
 
 error_chain!{
@@ -10,6 +12,8 @@ error_chain!{
         InvalidStatusCode(InvalidStatusCodeError);
         InvalidUri(InvalidUriError);
         Json(JsonError);
+        Query(QueryError);
+        Utf8(Utf8Error);
     }
 
     errors {
@@ -19,7 +23,7 @@ error_chain!{
         }
 
         MissingField(name: String) {
-            description("TODO")
+            description("A struct was built without a required field.")
             display(r#"missing required field "{}""#, name)
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,12 @@
 extern crate error_chain;
 extern crate http;
 extern crate ordermap;
+extern crate percent_encoding;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate serde_qs;
 
 mod builder;
 mod resource;
@@ -17,6 +19,7 @@ mod sealed {
 
 pub mod doc;
 pub mod error;
+pub mod query;
 pub mod value;
 
 #[doc(inline)]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,150 @@
+pub mod page;
+pub mod sort;
+
+use std::fmt::{self, Debug, Formatter};
+
+use percent_encoding::percent_decode;
+use serde_qs;
+
+use builder;
+use error::Error;
+use value::{Map, Set, Value};
+use self::sort::Direction;
+
+pub use self::page::Page;
+pub use self::sort::Sort;
+
+#[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
+pub struct Query {
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub fields: Map<Set>,
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub filter: Map<Value>,
+    #[serde(default, skip_serializing_if = "Set::is_empty")]
+    pub include: Set,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page: Option<Page>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort: Option<Sort>,
+    /// Private field for backwards compatibility.
+    #[serde(skip)]
+    _ext: (),
+}
+
+impl Query {
+    pub fn build() -> QueryBuilder {
+        Default::default()
+    }
+}
+
+impl Debug for Query {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Query")
+            .field("fields", &self.fields)
+            .field("filter", &self.filter)
+            .field("include", &self.include)
+            .field("page", &self.page)
+            .field("sort", &self.sort)
+            .finish()
+    }
+}
+
+#[derive(Default)]
+pub struct QueryBuilder {
+    fields: Vec<(String, Vec<String>)>,
+    filter: Vec<(String, Value)>,
+    include: Vec<String>,
+    page: Option<Page>,
+    sort: Option<(String, Direction)>,
+}
+
+impl QueryBuilder {
+    pub fn finalize(&mut self) -> Result<Query, Error> {
+        Ok(Query {
+            fields: builder::iter(&mut self.fields, |(k, mut v)| {
+                let k = k.parse()?;
+                let v = v.drain(..)
+                    .map(|item| item.parse())
+                    .collect::<Result<_, _>>()?;
+
+                Ok((k, v))
+            })?,
+            filter: builder::iter(&mut self.filter, |(k, v)| Ok((k.parse()?, v)))?,
+            include: builder::iter(&mut self.include, |key| key.parse())?,
+            page: builder::optional(&mut self.page),
+            sort: match self.sort.take() {
+                Some((field, direction)) => Some(Sort::new(field.parse()?, direction)),
+                None => None,
+            },
+            _ext: (),
+        })
+    }
+
+    pub fn fields<K, V>(&mut self, key: K, value: &[&str]) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let key = key.into();
+        let value = value.into_iter().map(|item| (*item).to_owned()).collect();
+
+        self.fields.push((key, value));
+        self
+    }
+
+    pub fn filter<K, V>(&mut self, key: K, value: V) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<Value>,
+    {
+        let key = key.into();
+        let value = value.into();
+
+        self.filter.push((key, value));
+        self
+    }
+
+    pub fn include<V>(&mut self, value: V) -> &mut Self
+    where
+        V: Into<String>,
+    {
+        self.include.push(value.into());
+        self
+    }
+
+    pub fn page(&mut self, number: u64, size: Option<u64>) -> &mut Self {
+        self.page = Some(Page::new(number, size));
+        self
+    }
+
+    pub fn sort<F>(&mut self, field: F, direction: Direction) -> &mut Self
+    where
+        F: Into<String>,
+    {
+        self.sort = Some((field.into(), direction));
+        self
+    }
+}
+
+pub fn from_slice(data: &[u8]) -> Result<Query, Error> {
+    let value = percent_decode(data).decode_utf8()?;
+    Ok(serde_qs::from_bytes(value.as_bytes())?)
+}
+
+pub fn from_str(data: &str) -> Result<Query, Error> {
+    let value = percent_decode(data.as_bytes()).decode_utf8()?;
+    Ok(serde_qs::from_str(value.as_ref())?)
+}
+
+pub fn to_string(query: &Query) -> Result<String, Error> {
+    use percent_encoding::{percent_encode, QUERY_ENCODE_SET};
+
+    let value = serde_qs::to_string(query)?;
+    let data = value.as_bytes();
+
+    Ok(percent_encode(data, QUERY_ENCODE_SET).collect())
+}
+
+pub fn to_vec(query: &Query) -> Result<Vec<u8>, Error> {
+    to_string(query).map(Vec::from)
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -18,9 +18,9 @@ pub use self::sort::Sort;
 #[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
 pub struct Query {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub fields: Map<Set<Key>>,
+    pub fields: Map<Key, Set<Key>>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub filter: Map<Value>,
+    pub filter: Map<Path, Value>,
     #[serde(default, skip_serializing_if = "Set::is_empty")]
     pub include: Set<Path>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,5 +1,3 @@
-mod path;
-
 pub mod page;
 pub mod sort;
 
@@ -10,11 +8,11 @@ use serde_qs;
 
 use builder;
 use error::Error;
-use value::{Key, Map, Set, Value};
+use value::{Map, Set, Value};
+use value::key::{Key, Path};
 use self::sort::Direction;
 
 pub use self::page::Page;
-pub use self::path::Path;
 pub use self::sort::Sort;
 
 #[derive(Clone, Default, Deserialize, PartialEq, Serialize)]

--- a/src/query/page.rs
+++ b/src/query/page.rs
@@ -1,0 +1,111 @@
+use std::fmt::{self, Debug, Formatter};
+
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Page {
+    pub number: u64,
+    pub size: Option<u64>,
+    /// Private field for backwards compatibility.
+    _ext: (),
+}
+
+impl Page {
+    pub fn new(number: u64, size: Option<u64>) -> Self {
+        let number = if number > 0 { number } else { 1 };
+
+        Page {
+            number,
+            size,
+            _ext: (),
+        }
+    }
+}
+
+impl Debug for Page {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Page")
+            .field("number", &self.number)
+            .field("size", &self.size)
+            .finish()
+    }
+}
+
+impl<'de> Deserialize<'de> for Page {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, MapAccess, Visitor};
+
+        const FIELDS: &'static [&'static str] = &["number", "size"];
+
+        #[derive(Debug, Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Number,
+            Size,
+        }
+
+        struct PageVisitor;
+
+        impl<'de> Visitor<'de> for PageVisitor {
+            type Value = Page;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, "an object containing json api pagination parameters")
+            }
+
+            fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut number = None;
+                let mut size = None;
+
+                while let Some(key) = access.next_key()? {
+                    match key {
+                        Field::Number if number.is_some() => {
+                            return Err(Error::duplicate_field("href"));
+                        }
+                        Field::Size if size.is_some() => {
+                            return Err(Error::duplicate_field("meta"));
+                        }
+                        Field::Number => {
+                            number = access.next_value()?;
+                        }
+                        Field::Size => {
+                            size = access.next_value()?;
+                        }
+                    }
+                }
+
+                Ok(Page::new(number.unwrap_or(1), size))
+            }
+        }
+
+        deserializer.deserialize_struct("Page", FIELDS, PageVisitor)
+    }
+}
+
+impl Serialize for Page {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Page", 2)?;
+        let number = &self.number;
+        let size = &self.size;
+
+        if *number != 1 {
+            state.serialize_field("number", number)?;
+        }
+
+        if let Some(ref value) = *size {
+            state.serialize_field("size", value)?;
+        }
+
+        state.end()
+    }
+}

--- a/src/query/page.rs
+++ b/src/query/page.rs
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for Page {
     {
         use serde::de::{Error, MapAccess, Visitor};
 
-        const FIELDS: &'static [&'static str] = &["number", "size"];
+        const FIELDS: &[&str] = &["number", "size"];
 
         #[derive(Debug, Deserialize)]
         #[serde(field_identifier, rename_all = "lowercase")]

--- a/src/query/page.rs
+++ b/src/query/page.rs
@@ -67,10 +67,10 @@ impl<'de> Deserialize<'de> for Page {
                 while let Some(key) = access.next_key()? {
                     match key {
                         Field::Number if number.is_some() => {
-                            return Err(Error::duplicate_field("href"));
+                            return Err(Error::duplicate_field("number"));
                         }
                         Field::Size if size.is_some() => {
-                            return Err(Error::duplicate_field("meta"));
+                            return Err(Error::duplicate_field("size"));
                         }
                         Field::Number => {
                             number = access.next_value()?;

--- a/src/query/path.rs
+++ b/src/query/path.rs
@@ -1,0 +1,153 @@
+use std::fmt::{self, Display, Formatter};
+use std::iter::FromIterator;
+use std::ops::Deref;
+use std::slice::Iter;
+use std::str::FromStr;
+
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use error::Error;
+use value::Key;
+
+const SEPERATOR: u8 = '.' as u8;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Path(Vec<Key>);
+
+impl Path {
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        let Path(ref keys) = *self;
+        let count = keys.len();
+
+        if count > 0 {
+            keys.iter()
+                .map(|key| key.len())
+                .fold(count - 1, |prev, next| prev + next)
+        } else {
+            count
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let capacity = self.len();
+        let bytes = Vec::with_capacity(capacity);
+
+        if capacity == 0 {
+            return bytes;
+        }
+
+        self.iter().fold(bytes, |mut bytes, key| {
+            if !bytes.is_empty() {
+                bytes.push(SEPERATOR);
+            }
+
+            bytes.extend_from_slice(key.as_bytes());
+            bytes
+        })
+    }
+
+    pub fn to_string(&self) -> String {
+        let bytes = self.to_bytes();
+        unsafe { String::from_utf8_unchecked(bytes) }
+    }
+}
+
+impl Display for Path {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+impl Deref for Path {
+    type Target = [Key];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Path> for String {
+    fn from(path: Path) -> Self {
+        path.to_string()
+    }
+}
+
+impl From<Path> for Vec<u8> {
+    fn from(path: Path) -> Self {
+        path.to_bytes()
+    }
+}
+
+impl FromIterator<Key> for Path {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Key>,
+    {
+        Path(Vec::from_iter(iter))
+    }
+}
+
+impl FromStr for Path {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.split('.').map(|item| item.parse()).collect()
+    }
+}
+
+impl IntoIterator for Path {
+    type Item = Key;
+    type IntoIter = <Vec<Key> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Path {
+    type Item = &'a Key;
+    type IntoIter = Iter<'a, Key>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for Path {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, Visitor};
+
+        struct PathVisitor;
+
+        impl<'de> Visitor<'de> for PathVisitor {
+            type Value = Path;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                f.write_str(r#"a string of json api member names, separated by a ".""#)
+            }
+
+            fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+                value.parse().map_err(Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(PathVisitor)
+    }
+}
+
+impl Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/src/query/sort.rs
+++ b/src/query/sort.rs
@@ -1,0 +1,161 @@
+use std::fmt::{self, Debug, Display, Formatter};
+use std::str::FromStr;
+
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use error::Error;
+use value::Key;
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct Sort {
+    pub direction: Direction,
+    pub field: Key,
+    /// Private field for backwards compatibility.
+    _ext: (),
+}
+
+impl Sort {
+    pub fn new(field: Key, direction: Direction) -> Self {
+        Sort {
+            direction,
+            field,
+            _ext: (),
+        }
+    }
+}
+
+impl Debug for Sort {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Sort")
+            .field("direction", &self.direction)
+            .field("field", &self.field)
+            .finish()
+    }
+}
+
+impl Display for Sort {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        if self.direction == Direction::Desc {
+            Display::fmt("-", fmtr)?;
+        }
+
+        Display::fmt(&self.field, fmtr)
+    }
+}
+
+impl FromStr for Sort {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.starts_with('-') {
+            Ok(Sort {
+                direction: Direction::Desc,
+                field: (&value[1..]).parse()?,
+                _ext: (),
+            })
+        } else {
+            Ok(Sort {
+                direction: Direction::Asc,
+                field: value.parse()?,
+                _ext: (),
+            })
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Sort {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, Visitor};
+
+        struct SortVisitor;
+
+        impl<'de> Visitor<'de> for SortVisitor {
+            type Value = Sort;
+
+            fn expecting(&self, f: &mut Formatter) -> fmt::Result {
+                write!(f, "a valid json api member name, optionally ")?;
+                write!(f, r#"prefixed with "-" to denote descending order"#)
+            }
+
+            fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+                value.parse().map_err(Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(SortVisitor)
+    }
+}
+
+impl Serialize for Sort {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = String::with_capacity(self.field.len() + 1);
+
+        if self.direction == Direction::Desc {
+            value.push('-');
+        }
+
+        value.push_str(&self.field);
+        value.serialize(serializer)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Direction {
+    Asc,
+    Desc,
+}
+
+impl Direction {
+    /// Returns `true` if the direction is [`Asc`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::query::Direction;
+    /// #
+    /// # fn main() {
+    /// let direction = Direction::Desc;
+    /// assert_eq!(direction.is_asc(), false);
+    ///
+    /// let direction = Direction::Asc;
+    /// assert_eq!(direction.is_asc(), true);
+    /// # }
+    /// ```
+    ///
+    /// [`Asc`]: #variant.Asc
+    pub fn is_asc(&self) -> bool {
+        *self == Direction::Asc
+    }
+
+    /// Returns `true` if the direction is [`Desc`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::query::Direction;
+    /// #
+    /// # fn main() {
+    /// let direction = Direction::Asc;
+    /// assert_eq!(direction.is_desc(), false);
+    ///
+    /// let direction = Direction::Desc;
+    /// assert_eq!(direction.is_desc(), true);
+    /// # }
+    /// ```
+    ///
+    /// [`Desc`]: #variant.Desc
+    pub fn is_desc(&self) -> bool {
+        *self == Direction::Desc
+    }
+}

--- a/src/query/sort.rs
+++ b/src/query/sort.rs
@@ -5,18 +5,18 @@ use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
 use error::Error;
-use value::Key;
+use query::Path;
 
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct Sort {
     pub direction: Direction,
-    pub field: Key,
+    pub field: Path,
     /// Private field for backwards compatibility.
     _ext: (),
 }
 
 impl Sort {
-    pub fn new(field: Key, direction: Direction) -> Self {
+    pub fn new(field: Path, direction: Direction) -> Self {
         Sort {
             direction,
             field,
@@ -35,12 +35,12 @@ impl Debug for Sort {
 }
 
 impl Display for Sort {
-    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if self.direction == Direction::Desc {
-            Display::fmt("-", fmtr)?;
+            Display::fmt("-", f)?;
         }
 
-        Display::fmt(&self.field, fmtr)
+        Display::fmt(&self.field, f)
     }
 }
 
@@ -101,7 +101,7 @@ impl Serialize for Sort {
             value.push('-');
         }
 
-        value.push_str(&self.field);
+        value.push_str(&self.field.to_string());
         value.serialize(serializer)
     }
 }

--- a/src/value/key/mod.rs
+++ b/src/value/key/mod.rs
@@ -1,5 +1,7 @@
+mod path;
+
 use std::borrow::Borrow;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -8,12 +10,14 @@ use serde::ser::{Serialize, Serializer};
 
 use error::Error;
 
+pub use self::path::Path;
+
 /// An immutable wrapper around [`String`] that enforces compliance
 /// with JSON API [Member Names].
 ///
 /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
 /// [Member Names]: http://jsonapi.org/format/#document-member-names
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Key(String);
 
 impl AsRef<[u8]> for Key {
@@ -31,6 +35,12 @@ impl AsRef<str> for Key {
 impl Borrow<str> for Key {
     fn borrow(&self) -> &str {
         &**self
+    }
+}
+
+impl Debug for Key {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_tuple("Key").field(&self.0.as_str()).finish()
     }
 }
 

--- a/src/value/key/path.rs
+++ b/src/value/key/path.rs
@@ -1,5 +1,4 @@
-use std::cmp::PartialEq;
-use std::fmt::{self, Debug, Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::iter::FromIterator;
 use std::ops::Deref;
 use std::slice::Iter;
@@ -18,20 +17,16 @@ use value::Key;
 /// [Member Names]: http://jsonapi.org/format/#document-member-names
 /// [Path]: ./struct.Path.html
 /// [relationship path]: http://jsonapi.org/format/#fetching-includes
-#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Path {
-    inner: Vec<Key>,
-}
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Path(Vec<Key>);
 
 impl Path {
     pub fn new() -> Self {
-        let inner = Vec::new();
-        Path { inner }
+        Default::default()
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        let inner = Vec::with_capacity(capacity);
-        Path { inner }
+        Path(Vec::with_capacity(capacity))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -39,10 +34,11 @@ impl Path {
     }
 
     pub fn len(&self) -> usize {
-        let count = self.inner.len();
+        let Path(ref keys) = *self;
+        let count = keys.len();
 
         if count > 0 {
-            self.iter()
+            keys.iter()
                 .map(|key| key.len())
                 .fold(count - 1, |prev, next| prev + next)
         } else {
@@ -60,7 +56,7 @@ impl Path {
 
         self.iter().fold(bytes, |mut bytes, key| {
             if !bytes.is_empty() {
-                bytes.push('.' as u8);
+                bytes.push(b'.');
             }
 
             bytes.extend_from_slice(key.as_bytes());
@@ -74,17 +70,11 @@ impl Path {
     }
 }
 
-impl Debug for Path {
-    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
-        fmtr.debug_list().entries(self.iter()).finish()
-    }
-}
-
 impl Deref for Path {
     type Target = [Key];
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &self.0
     }
 }
 
@@ -111,8 +101,7 @@ impl FromIterator<Key> for Path {
     where
         I: IntoIterator<Item = Key>,
     {
-        let inner = Vec::from_iter(iter);
-        Path { inner }
+        Path(Vec::from_iter(iter))
     }
 }
 
@@ -129,7 +118,7 @@ impl IntoIterator for Path {
     type IntoIter = <Vec<Key> as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
+        self.0.into_iter()
     }
 }
 

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -1,5 +1,6 @@
 use std::iter::FromIterator;
 use std::ops::RangeFull;
+use std::fmt::{self, Debug, Formatter};
 
 use ordermap::{self, OrderMap};
 use serde::de::{Deserialize, Deserializer};
@@ -7,7 +8,7 @@ use serde::ser::{Serialize, Serializer};
 
 use super::Key;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Map<T> {
     inner: OrderMap<Key, T>,
 }
@@ -78,6 +79,12 @@ impl<T> Map<T> {
     pub fn values_mut(&mut self) -> ValuesMut<T> {
         let iter = self.inner.values_mut();
         ValuesMut { iter }
+    }
+}
+
+impl<T: Debug> Debug for Map<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
     }
 }
 

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -1,19 +1,24 @@
 use std::iter::FromIterator;
 use std::ops::RangeFull;
 use std::fmt::{self, Debug, Formatter};
+use std::hash::Hash;
 
-use ordermap::{self, OrderMap};
+use ordermap::{self, Equivalent, OrderMap};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
-use super::Key;
-
-#[derive(Clone, PartialEq)]
-pub struct Map<T> {
-    inner: OrderMap<Key, T>,
+#[derive(Clone, Eq, PartialEq)]
+pub struct Map<K, V>
+where
+    K: Eq + Hash,
+{
+    inner: OrderMap<K, V>,
 }
 
-impl<T> Map<T> {
+impl<K, V> Map<K, V>
+where
+    K: Eq + Hash,
+{
     pub fn new() -> Self {
         Default::default()
     }
@@ -27,34 +32,40 @@ impl<T> Map<T> {
         self.inner.clear();
     }
 
-    pub fn contains_key(&self, key: &str) -> bool {
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    where
+        Q: Equivalent<K> + Hash,
+    {
         self.inner.contains_key(key)
     }
 
-    pub fn drain(&mut self, range: RangeFull) -> Drain<T> {
+    pub fn drain(&mut self, range: RangeFull) -> Drain<K, V> {
         let iter = self.inner.drain(range);
         Drain { iter }
     }
 
-    pub fn get(&self, key: &str) -> Option<&T> {
+    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    where
+        Q: Equivalent<K> + Hash,
+    {
         self.inner.get(key)
     }
 
-    pub fn insert(&mut self, key: Key, value: T) -> Option<T> {
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.inner.insert(key, value)
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<K, V> {
         let iter = self.inner.iter();
         Iter { iter }
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<T> {
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
         let iter = self.inner.iter_mut();
         IterMut { iter }
     }
 
-    pub fn keys(&self) -> Keys<T> {
+    pub fn keys(&self) -> Keys<K, V> {
         let iter = self.inner.keys();
         Keys { iter }
     }
@@ -67,85 +78,110 @@ impl<T> Map<T> {
         self.len() == 0
     }
 
-    pub fn remove(&mut self, key: &str) -> Option<T> {
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        Q: Equivalent<K> + Hash,
+    {
         self.inner.remove(key)
     }
 
-    pub fn values(&self) -> Values<T> {
+    pub fn values(&self) -> Values<K, V> {
         let iter = self.inner.values();
         Values { iter }
     }
 
-    pub fn values_mut(&mut self) -> ValuesMut<T> {
+    pub fn values_mut(&mut self) -> ValuesMut<K, V> {
         let iter = self.inner.values_mut();
         ValuesMut { iter }
     }
 }
 
-impl<T: Debug> Debug for Map<T> {
+impl<K, V> Debug for Map<K, V>
+where
+    K: Debug + Eq + Hash,
+    V: Debug,
+{
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
     }
 }
 
-impl<T> Default for Map<T> {
+impl<K, V> Default for Map<K, V>
+where
+    K: Eq + Hash,
+{
     fn default() -> Self {
         let inner = Default::default();
         Map { inner }
     }
 }
 
-impl<T> Extend<(Key, T)> for Map<T> {
+impl<K, V> Extend<(K, V)> for Map<K, V>
+where
+    K: Eq + Hash,
+{
     fn extend<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = (Key, T)>,
+        I: IntoIterator<Item = (K, V)>,
     {
         self.inner.extend(iter);
     }
 }
 
-impl<T> FromIterator<(Key, T)> for Map<T> {
+impl<K, V> FromIterator<(K, V)> for Map<K, V>
+where
+    K: Eq + Hash,
+{
     fn from_iter<I>(iter: I) -> Self
     where
-        I: IntoIterator<Item = (Key, T)>,
+        I: IntoIterator<Item = (K, V)>,
     {
         let inner = OrderMap::from_iter(iter);
         Map { inner }
     }
 }
 
-impl<T> IntoIterator for Map<T> {
-    type Item = (Key, T);
-    type IntoIter = IntoIter<T>;
+impl<K, V> IntoIterator for Map<K, V>
+where
+    K: Eq + Hash,
+{
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            iter: self.inner.into_iter(),
-        }
+        let iter = self.inner.into_iter();
+        IntoIter { iter }
     }
 }
 
-impl<'a, T> IntoIterator for &'a Map<T> {
-    type Item = (&'a Key, &'a T);
-    type IntoIter = Iter<'a, T>;
+impl<'a, K, V> IntoIterator for &'a Map<K, V>
+where
+    K: Eq + Hash,
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut Map<T> {
-    type Item = (&'a Key, &'a mut T);
-    type IntoIter = IterMut<'a, T>;
+impl<'a, K, V> IntoIterator for &'a mut Map<K, V>
+where
+    K: Eq + Hash,
+{
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
     }
 }
 
-impl<'de, T> Deserialize<'de> for Map<T>
+impl<'de, K, V> Deserialize<'de> for Map<K, V>
 where
-    T: Deserialize<'de>,
+    K: Deserialize<'de> + Eq + Hash,
+    V: Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -155,7 +191,11 @@ where
     }
 }
 
-impl<T: Serialize> Serialize for Map<T> {
+impl<K, V> Serialize for Map<K, V>
+where
+    K: Eq + Hash + Serialize,
+    V: Serialize,
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -164,12 +204,12 @@ impl<T: Serialize> Serialize for Map<T> {
     }
 }
 
-pub struct Drain<'a, T: 'a> {
-    iter: ordermap::Drain<'a, Key, T>,
+pub struct Drain<'a, K: 'a, V: 'a> {
+    iter: ordermap::Drain<'a, K, V>,
 }
 
-impl<'a, T> Iterator for Drain<'a, T> {
-    type Item = (Key, T);
+impl<'a, K, V> Iterator for Drain<'a, K, V> {
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -180,12 +220,12 @@ impl<'a, T> Iterator for Drain<'a, T> {
     }
 }
 
-pub struct Iter<'a, T: 'a> {
-    iter: ordermap::Iter<'a, Key, T>,
+pub struct Iter<'a, K: 'a, V: 'a> {
+    iter: ordermap::Iter<'a, K, V>,
 }
 
-impl<'a, T> Iterator for Iter<'a, T> {
-    type Item = (&'a Key, &'a T);
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -208,24 +248,24 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-pub struct IterMut<'a, T: 'a> {
-    iter: ordermap::IterMut<'a, Key, T>,
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    iter: ordermap::IterMut<'a, K, V>,
 }
 
-impl<'a, T> Iterator for IterMut<'a, T> {
-    type Item = (&'a Key, &'a mut T);
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -248,24 +288,24 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T> {
+impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-pub struct IntoIter<T> {
-    iter: ordermap::IntoIter<Key, T>,
+pub struct IntoIter<K, V> {
+    iter: ordermap::IntoIter<K, V>,
 }
 
-impl<T> Iterator for IntoIter<T> {
-    type Item = (Key, T);
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -288,24 +328,24 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for IntoIter<T> {
+impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<T> ExactSizeIterator for IntoIter<T> {
+impl<K, V> ExactSizeIterator for IntoIter<K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-pub struct Keys<'a, T: 'a> {
-    iter: ordermap::Keys<'a, Key, T>,
+pub struct Keys<'a, K: 'a, V: 'a> {
+    iter: ordermap::Keys<'a, K, V>,
 }
 
-impl<'a, T> Iterator for Keys<'a, T> {
-    type Item = &'a Key;
+impl<'a, K, V> Iterator for Keys<'a, K, V> {
+    type Item = &'a K;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -328,24 +368,24 @@ impl<'a, T> Iterator for Keys<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Keys<'a, T> {
+impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a, T> ExactSizeIterator for Keys<'a, T> {
+impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-pub struct Values<'a, T: 'a> {
-    iter: ordermap::Values<'a, Key, T>,
+pub struct Values<'a, K: 'a, V: 'a> {
+    iter: ordermap::Values<'a, K, V>,
 }
 
-impl<'a, T> Iterator for Values<'a, T> {
-    type Item = &'a T;
+impl<'a, K, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -368,24 +408,24 @@ impl<'a, T> Iterator for Values<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Values<'a, T> {
+impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a, T> ExactSizeIterator for Values<'a, T> {
+impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
-pub struct ValuesMut<'a, T: 'a> {
-    iter: ordermap::ValuesMut<'a, Key, T>,
+pub struct ValuesMut<'a, K: 'a, V: 'a> {
+    iter: ordermap::ValuesMut<'a, K, V>,
 }
 
-impl<'a, T> Iterator for ValuesMut<'a, T> {
-    type Item = &'a mut T;
+impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -408,13 +448,13 @@ impl<'a, T> Iterator for ValuesMut<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for ValuesMut<'a, T> {
+impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
     }
 }
 
-impl<'a, T> ExactSizeIterator for ValuesMut<'a, T> {
+impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
     fn len(&self) -> usize {
         self.iter.len()
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -24,7 +24,7 @@ pub enum Value {
     Array(Vec<Value>),
     Bool(bool),
     Number(Number),
-    Object(Map<Value>),
+    Object(Map<Key, Value>),
     String(String),
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,5 +1,4 @@
-mod key;
-
+pub mod key;
 pub mod map;
 pub mod set;
 

--- a/src/value/set.rs
+++ b/src/value/set.rs
@@ -1,4 +1,3 @@
-use std::cmp::Eq;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
@@ -6,22 +5,24 @@ use std::marker::PhantomData;
 use std::ops::RangeFull;
 use std::str::FromStr;
 
-use ordermap::{self, Equivalent, Keys, OrderMap};
+use ordermap::Equivalent;
 use serde::ser::{Serialize, Serializer};
 use serde::de::{Deserialize, Deserializer, Visitor};
 
+use value::map::{self, Keys, Map};
+
 #[derive(Clone, Eq, PartialEq)]
-pub struct Set<T: Eq + FromStr + Hash> {
-    inner: OrderMap<T, ()>,
+pub struct Set<T: Eq + Hash> {
+    inner: Map<T, ()>,
 }
 
-impl<T: Eq + FromStr + Hash> Set<T> {
+impl<T: Eq + Hash> Set<T> {
     pub fn new() -> Self {
         Default::default()
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        let inner = OrderMap::with_capacity(capacity);
+        let inner = Map::with_capacity(capacity);
         Set { inner }
     }
 
@@ -31,7 +32,7 @@ impl<T: Eq + FromStr + Hash> Set<T> {
 
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
-        Q: Hash + Equivalent<T>,
+        Q: Equivalent<T> + Hash,
     {
         self.inner.contains_key(key)
     }
@@ -60,7 +61,7 @@ impl<T: Eq + FromStr + Hash> Set<T> {
 
     pub fn remove<Q>(&mut self, key: &Q) -> bool
     where
-        Q: Hash + Equivalent<T>,
+        Q: Equivalent<T> + Hash,
     {
         self.inner.remove(key).is_some()
     }
@@ -72,14 +73,14 @@ impl<T: Debug + Eq + FromStr + Hash> Debug for Set<T> {
     }
 }
 
-impl<T: Eq + FromStr + Hash> Default for Set<T> {
+impl<T: Eq + Hash> Default for Set<T> {
     fn default() -> Self {
         let inner = Default::default();
         Set { inner }
     }
 }
 
-impl<T: Display + Eq + FromStr + Hash> Display for Set<T> {
+impl<T: Display + Eq + Hash> Display for Set<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let sep = ',';
 
@@ -115,7 +116,7 @@ impl<T: Eq + FromStr + Hash> FromIterator<T> for Set<T> {
     }
 }
 
-impl<T: Eq + FromStr + Hash> IntoIterator for Set<T> {
+impl<T: Eq + Hash> IntoIterator for Set<T> {
     type Item = T;
     type IntoIter = IntoIter<Self::Item>;
 
@@ -125,7 +126,7 @@ impl<T: Eq + FromStr + Hash> IntoIterator for Set<T> {
     }
 }
 
-impl<'a, T: Eq + FromStr + Hash> IntoIterator for &'a Set<T> {
+impl<'a, T: Eq + Hash> IntoIterator for &'a Set<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
@@ -189,7 +190,7 @@ where
     }
 }
 
-impl<T: Display + Eq + FromStr + Hash> Serialize for Set<T> {
+impl<T: Display + Eq + Hash> Serialize for Set<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -199,7 +200,7 @@ impl<T: Display + Eq + FromStr + Hash> Serialize for Set<T> {
 }
 
 pub struct Drain<'a, T: 'a> {
-    iter: ordermap::Drain<'a, T, ()>,
+    iter: map::Drain<'a, T, ()>,
 }
 
 impl<'a, T> Iterator for Drain<'a, T> {
@@ -255,7 +256,7 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {
 }
 
 pub struct IntoIter<T> {
-    iter: ordermap::IntoIter<T, ()>,
+    iter: map::IntoIter<T, ()>,
 }
 
 impl<T> Iterator for IntoIter<T> {


### PR DESCRIPTION
Adds support for encoding and decoding query parameters such as:

- [Filtering](http://jsonapi.org/format/#fetching-filtering)
- [Includes](http://jsonapi.org/format/#fetching-includes)
- [Pagination](http://jsonapi.org/format/#fetching-pagination)
- [Sorting](http://jsonapi.org/format/#fetching-sorting)
- [Sparse Fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets)

Under the hood, query parameter encoding and decoding is implemented with [serde_qs](/samscott89/serde_qs) and [percent_encoding](https://github.com/servo/rust-url/). Query strings are percent decoded before deserialization and percent encoded before serialization to enforce spec compliance.