### PR TITLE
fix: ignore unknown fields

### DIFF
--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -3,7 +3,6 @@ use doc::Link;
 use value::{Key, Map, StatusCode, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Error {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
@@ -115,7 +114,6 @@ impl ErrorBuilder {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Source {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pointer: Option<String>,

--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -3,7 +3,6 @@ use error::Error;
 use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Identifier {
     pub id: String,
     #[serde(rename = "type")]

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -23,7 +23,6 @@ pub use self::specification::JsonApi;
 pub use self::specification::Version;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Document<T: PrimaryData> {
     pub data: Data<T>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -121,7 +120,6 @@ impl<T: PrimaryData> Default for DocumentBuilder<T> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct ErrorDocument {
     pub errors: Vec<Error>,
     #[serde(default)]

--- a/src/doc/object.rs
+++ b/src/doc/object.rs
@@ -4,7 +4,6 @@ use error::Error;
 use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Object {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub attributes: Map<Key, Value>,

--- a/src/doc/relationship.rs
+++ b/src/doc/relationship.rs
@@ -4,7 +4,6 @@ use error::Error;
 use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Relationship {
     pub data: Data<Identifier>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]

--- a/src/doc/specification.rs
+++ b/src/doc/specification.rs
@@ -9,7 +9,6 @@ use error::Error;
 use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct JsonApi {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub meta: Map<Key, Value>,


### PR DESCRIPTION
In the [Document Structure](http://jsonapi.org/format/#document-structure) section of the spec, it clearly states:

> Client and server implementations MUST ignore members not recognized by this specification.