### PR TITLE
refactor: do not show private _ext field when debugging

### DIFF
--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -1,8 +1,10 @@
+use std::fmt::{self, Debug, Formatter};
+
 use builder;
 use doc::Link;
 use value::{Key, Map, StatusCode, Value};
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
 pub struct Error {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
@@ -28,6 +30,21 @@ pub struct Error {
 impl Error {
     pub fn build() -> ErrorBuilder {
         Default::default()
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Error")
+            .field("code", &self.code)
+            .field("detail", &self.detail)
+            .field("id", &self.id)
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .field("source", &self.source)
+            .field("status", &self.status)
+            .field("title", &self.title)
+            .finish()
     }
 }
 
@@ -113,14 +130,24 @@ impl ErrorBuilder {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Source {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pointer: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parameter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pointer: Option<String>,
     /// Private field for backwards compatibility.
+    #[serde(skip)]
     _ext: (),
+}
+
+impl Debug for Source {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Source")
+            .field("parameter", &self.parameter)
+            .field("pointer", &self.pointer)
+            .finish()
+    }
 }
 
 mod serde_status {

--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -1,8 +1,10 @@
+use std::fmt::{self, Debug, Formatter};
+
 use builder;
 use error::Error;
 use value::{Key, Map, Value};
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub struct Identifier {
     pub id: String,
     #[serde(rename = "type")]
@@ -17,6 +19,16 @@ pub struct Identifier {
 impl Identifier {
     pub fn build() -> IdentifierBuilder {
         Default::default()
+    }
+}
+
+impl Debug for Identifier {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Identifier")
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("meta", &self.meta)
+            .finish()
     }
 }
 

--- a/src/doc/link.rs
+++ b/src/doc/link.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -10,7 +10,7 @@ use builder;
 use error::Error;
 use value::{Key, Map, Value};
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Link {
     pub href: Uri,
     pub meta: Map<Key, Value>,
@@ -24,6 +24,15 @@ impl Link {
     }
 }
 
+impl Debug for Link {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Link")
+            .field("href", &self.href)
+            .field("meta", &self.meta)
+            .finish()
+    }
+}
+
 impl Deref for Link {
     type Target = Uri;
 
@@ -34,7 +43,7 @@ impl Deref for Link {
 
 impl Display for Link {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        self.href.fmt(f)
+        write!(f, "{}", self.href)
     }
 }
 

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -5,6 +5,7 @@ pub mod object;
 pub mod relationship;
 pub mod specification;
 
+use std::fmt::{self, Debug, Formatter};
 use std::iter::FromIterator;
 
 use serde::ser::Serialize;
@@ -22,7 +23,7 @@ pub use self::specification::JsonApi;
 #[doc(inline)]
 pub use self::specification::Version;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Document<T: PrimaryData> {
     pub data: Data<T>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -41,6 +42,18 @@ pub struct Document<T: PrimaryData> {
 impl<T: PrimaryData> Document<T> {
     pub fn build() -> DocumentBuilder<T> {
         Default::default()
+    }
+}
+
+impl<T: Debug + PrimaryData> Debug for Document<T> {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Document")
+            .field("data", &self.data)
+            .field("included", &self.included)
+            .field("jsonapi", &self.jsonapi)
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .finish()
     }
 }
 
@@ -119,7 +132,7 @@ impl<T: PrimaryData> Default for DocumentBuilder<T> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ErrorDocument {
     pub errors: Vec<Error>,
     #[serde(default)]
@@ -136,6 +149,17 @@ pub struct ErrorDocument {
 impl ErrorDocument {
     pub fn build() -> ErrorDocumentBuilder {
         Default::default()
+    }
+}
+
+impl Debug for ErrorDocument {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Document")
+            .field("errors", &self.errors)
+            .field("jsonapi", &self.jsonapi)
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .finish()
     }
 }
 

--- a/src/doc/object.rs
+++ b/src/doc/object.rs
@@ -1,9 +1,11 @@
+use std::fmt::{self, Debug, Formatter};
+
 use builder;
 use doc::{Link, Relationship};
 use error::Error;
 use value::{Key, Map, Value};
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub struct Object {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub attributes: Map<Key, Value>,
@@ -24,6 +26,19 @@ pub struct Object {
 impl Object {
     pub fn build() -> ObjectBuilder {
         Default::default()
+    }
+}
+
+impl Debug for Object {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Object")
+            .field("attributes", &self.attributes)
+            .field("id", &self.id)
+            .field("kind", &self.kind)
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .field("relationships", &self.relationships)
+            .finish()
     }
 }
 

--- a/src/doc/relationship.rs
+++ b/src/doc/relationship.rs
@@ -1,9 +1,11 @@
+use std::fmt::{self, Debug, Formatter};
+
 use builder;
 use doc::{Data, Identifier, Link};
 use error::Error;
 use value::{Key, Map, Value};
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub struct Relationship {
     pub data: Data<Identifier>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
@@ -18,6 +20,16 @@ pub struct Relationship {
 impl Relationship {
     pub fn build() -> RelationshipBuilder {
         Default::default()
+    }
+}
+
+impl Debug for Relationship {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("Relationship")
+            .field("data", &self.data)
+            .field("links", &self.links)
+            .field("meta", &self.meta)
+            .finish()
     }
 }
 

--- a/src/doc/specification.rs
+++ b/src/doc/specification.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
 use serde::de::{Deserialize, Deserializer, Error as DeError};
@@ -8,13 +8,23 @@ use builder;
 use error::Error;
 use value::{Key, Map, Value};
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Default, Deserialize, PartialEq, Serialize)]
 pub struct JsonApi {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub meta: Map<Key, Value>,
     pub version: Version,
+    /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),
+}
+
+impl Debug for JsonApi {
+    fn fmt(&self, fmtr: &mut Formatter) -> fmt::Result {
+        fmtr.debug_struct("JsonApi")
+            .field("meta", &self.meta)
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
This is probably unnecessary but the `_ext` fields stick out like a sore thumb when types are printed with the debug formatter.