### PR TITLE
feat: document and stabalize apis in the value module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ repository = "zacharygolba/json-api-rs"
 repository = "zacharygolba/json-api-rs"
 
 [dependencies]
-Inflector = "0.11.0"
 error-chain = "0.11"
 http = "0.1"
 percent-encoding = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ repository = "zacharygolba/json-api-rs"
 repository = "zacharygolba/json-api-rs"
 
 [dependencies]
+Inflector = "0.11.0"
 error-chain = "0.11"
 http = "0.1"
 percent-encoding = "1.0"

--- a/benches/key.rs
+++ b/benches/key.rs
@@ -19,7 +19,7 @@ const SOURCES: [&str; 6] = [
 
 #[bench]
 fn from_str(b: &mut Bencher) {
-    b.iter(|| for source in SOURCES.iter() {
+    b.iter(|| for source in &SOURCES {
         Key::from_str(source).unwrap();
     })
 }

--- a/benches/key.rs
+++ b/benches/key.rs
@@ -1,0 +1,25 @@
+#![feature(test)]
+
+extern crate json_api;
+extern crate test;
+
+use std::str::FromStr;
+
+use json_api::value::Key;
+use test::Bencher;
+
+const SOURCES: [&str; 6] = [
+    "articles",
+    "comments",
+    "likes",
+    "notification_settings",
+    "shoppingCarts",
+    "users",
+];
+
+#[bench]
+fn from_str(b: &mut Bencher) {
+    b.iter(|| for source in SOURCES.iter() {
+        Key::from_str(source).unwrap();
+    })
+}

--- a/rocket/src/error.rs
+++ b/rocket/src/error.rs
@@ -1,5 +1,4 @@
-use json_api::value::StatusCode;
-
+use json_api::http::StatusCode;
 use rocket::{Catcher, Error as RocketError, Request, Response};
 use rocket::http::Status;
 

--- a/rocket/src/request.rs
+++ b/rocket/src/request.rs
@@ -1,6 +1,7 @@
 use json_api::Error;
 use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
-use json_api::value::{map, set, Key, Path, Set, Value};
+use json_api::value::{Key, Path, Value};
+use json_api::value::collections::{map, set, Set};
 use rocket::Outcome;
 use rocket::http::Status;
 use rocket::request::{self, FromRequest, Request};

--- a/rocket/src/request.rs
+++ b/rocket/src/request.rs
@@ -1,7 +1,6 @@
 use json_api::Error;
 use json_api::query::{self, Page, Query as JsonApiQuery, Sort};
-use json_api::value::{map, set, Set, Value};
-use json_api::value::key::{Key, Path};
+use json_api::value::{map, set, Key, Path, Set, Value};
 use rocket::Outcome;
 use rocket::http::Status;
 use rocket::request::{self, FromRequest, Request};

--- a/rocket/src/request.rs
+++ b/rocket/src/request.rs
@@ -18,7 +18,7 @@ impl Query {
         self.inner
     }
 
-    pub fn fields(&self) -> map::Iter<Key, Set<Key>> {
+    pub fn fields(&self) -> map::Iter<Key, Set> {
         self.inner.fields.iter()
     }
 

--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -1,6 +1,7 @@
 use builder;
 use doc::Link;
-use value::{Key, Map, StatusCode, Value};
+use http::StatusCode;
+use value::{Key, Map, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Error {
@@ -130,7 +131,7 @@ mod serde_status {
     use serde::de::{Deserializer, Error, Visitor};
     use serde::ser::Serializer;
 
-    use value::StatusCode;
+    use http::StatusCode;
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<StatusCode>, D::Error>
     where

--- a/src/doc/error.rs
+++ b/src/doc/error.rs
@@ -14,7 +14,7 @@ pub struct Error {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<Source>,
     #[serde(skip_serializing_if = "Option::is_none", with = "serde_status")]

--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -8,7 +8,7 @@ pub struct Identifier {
     #[serde(rename = "type")]
     pub kind: Key,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/link.rs
+++ b/src/doc/link.rs
@@ -8,12 +8,12 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 use builder;
 use error::Error;
-use value::{Key, Map, Value};
+use value::{Map, Value};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Link {
     pub href: Uri,
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     /// Private field for backwards compatibility.
     _ext: (),
 }

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -32,7 +32,7 @@ pub struct Document<T: PrimaryData> {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),
@@ -127,7 +127,7 @@ pub struct ErrorDocument {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/object.rs
+++ b/src/doc/object.rs
@@ -6,14 +6,14 @@ use value::{Key, Map, Value};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Object {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub attributes: Map<Key, Value>,
+    pub attributes: Map,
     pub id: String,
     #[serde(rename = "type")]
     pub kind: Key,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub relationships: Map<Key, Relationship>,
     /// Private field for backwards compatibility.

--- a/src/doc/relationship.rs
+++ b/src/doc/relationship.rs
@@ -9,7 +9,7 @@ pub struct Relationship {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub links: Map<Key, Link>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     /// Private field for backwards compatibility.
     #[serde(skip)]
     _ext: (),

--- a/src/doc/specification.rs
+++ b/src/doc/specification.rs
@@ -6,12 +6,12 @@ use serde::ser::{Serialize, Serializer};
 
 use builder;
 use error::Error;
-use value::{Key, Map, Value};
+use value::{Map, Value};
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct JsonApi {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub meta: Map<Key, Value>,
+    pub meta: Map,
     pub version: Version,
     /// Private field for backwards compatibility.
     #[serde(skip)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate error_chain;
-extern crate inflector;
 extern crate ordermap;
 extern crate percent_encoding;
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate error_chain;
-extern crate http;
+extern crate inflector;
 extern crate ordermap;
 extern crate percent_encoding;
 extern crate serde;
@@ -8,6 +8,8 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_qs;
+
+pub extern crate http;
 
 mod builder;
 mod resource;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -15,7 +15,7 @@ pub use self::sort::Sort;
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Query {
     #[serde(default, skip_serializing_if = "Map::is_empty")]
-    pub fields: Map<Key, Set<Key>>,
+    pub fields: Map<Key, Set>,
     #[serde(default, skip_serializing_if = "Map::is_empty")]
     pub filter: Map<Path, Value>,
     #[serde(default, skip_serializing_if = "Set::is_empty")]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,8 +7,7 @@ use serde_qs;
 use self::sort::Direction;
 use builder;
 use error::Error;
-use value::{Map, Set, Value};
-use value::key::{Key, Path};
+use value::{Key, Map, Path, Set, Value};
 
 pub use self::page::Page;
 pub use self::sort::Sort;

--- a/src/query/sort.rs
+++ b/src/query/sort.rs
@@ -222,7 +222,7 @@ impl Neg for Direction {
 #[cfg(test)]
 mod tests {
     use super::{Direction, Sort};
-    use value::key::Path;
+    use value::Path;
 
     #[test]
     fn direction_is_asc() {

--- a/src/value/collections/map.rs
+++ b/src/value/collections/map.rs
@@ -3,6 +3,7 @@
 //! The types in this module are commonly used as the underlying data structure of
 //! arbitrary objects found in JSON API data.
 
+use std::fmt::{self, Debug, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops::RangeFull;
@@ -15,7 +16,7 @@ use value::{Key, Value};
 use value::collections::Equivalent;
 
 /// A hash map implementation with consistent ordering.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Map<K = Key, V = Value>
 where
     K: Eq + Hash,
@@ -448,6 +449,16 @@ where
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
         let iter = self.inner.values_mut();
         ValuesMut { iter }
+    }
+}
+
+impl<K, V> Debug for Map<K, V>
+where
+    K: Debug + Eq + Hash,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_map().entries(self).finish()
     }
 }
 

--- a/src/value/collections/map.rs
+++ b/src/value/collections/map.rs
@@ -7,11 +7,12 @@ use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops::RangeFull;
 
-use ordermap::{self, Equivalent, OrderMap};
+use ordermap::{self, OrderMap};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
 use value::{Key, Value};
+use value::collections::Equivalent;
 
 /// A hash map implementation with consistent ordering.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/value/collections/mod.rs
+++ b/src/value/collections/mod.rs
@@ -1,0 +1,9 @@
+//! Collection types with consistent ordering.
+
+pub mod map;
+pub mod set;
+
+pub use ordermap::Equivalent;
+
+pub use self::map::Map;
+pub use self::set::Set;

--- a/src/value/collections/set.rs
+++ b/src/value/collections/set.rs
@@ -1,6 +1,6 @@
 //! A hash set implemented as a `Map` where the value is `()`.
 
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
@@ -15,7 +15,7 @@ use value::collections::Equivalent;
 use value::collections::map::{self, Keys, Map};
 
 /// A hash set implemented as a `Map` where the value is `()`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Set<T: Eq + Hash = Key> {
     inner: Map<T, ()>,
 }
@@ -306,6 +306,12 @@ impl<T: Eq + Hash> Set<T> {
     /// [`ordermap`]: https://docs.rs/ordermap
     pub fn reserve(&mut self, additional: usize) {
         self.inner.reserve(additional)
+    }
+}
+
+impl<T: Debug + Eq + Hash> Debug for Set<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_set().entries(self).finish()
     }
 }
 

--- a/src/value/collections/set.rs
+++ b/src/value/collections/set.rs
@@ -7,12 +7,12 @@ use std::marker::PhantomData;
 use std::ops::RangeFull;
 use std::str::FromStr;
 
-use ordermap::Equivalent;
 use serde::de::{Deserialize, Deserializer, Visitor};
 use serde::ser::{Serialize, Serializer};
 
 use value::Key;
-use value::map::{self, Keys, Map};
+use value::collections::Equivalent;
+use value::collections::map::{self, Keys, Map};
 
 /// A hash set implemented as a `Map` where the value is `()`.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/value/convert.rs
+++ b/src/value/convert.rs
@@ -7,7 +7,7 @@ use serde_json::{self, Value as JsonValue};
 use error::Error;
 use value::Value;
 
-/// Interpret a JSON API value as an instance of type `T`.
+/// Convert a `T` into a value.
 pub fn to_value<T>(value: T) -> Result<Value, Error>
 where
     T: Serialize,
@@ -15,7 +15,7 @@ where
     from_json(serde_json::to_value(value)?)
 }
 
-/// Convert a `T` into a JSON API value.
+/// Interpret a value as an instance of type `T`.
 pub fn from_value<T>(value: Value) -> Result<T, Error>
 where
     T: DeserializeOwned,

--- a/src/value/convert.rs
+++ b/src/value/convert.rs
@@ -1,0 +1,55 @@
+//! Functions that convert types to and from a `Value`.
+
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json::{self, Value as JsonValue};
+
+use error::Error;
+use value::Value;
+
+/// Interpret a JSON API value as an instance of type `T`.
+pub fn to_value<T>(value: T) -> Result<Value, Error>
+where
+    T: Serialize,
+{
+    from_json(serde_json::to_value(value)?)
+}
+
+/// Convert a `T` into a JSON API value.
+pub fn from_value<T>(value: Value) -> Result<T, Error>
+where
+    T: DeserializeOwned,
+{
+    Ok(T::deserialize(to_json(value))?)
+}
+
+pub(crate) fn to_json(value: Value) -> JsonValue {
+    match value {
+        Value::Null => JsonValue::Null,
+        Value::Array(inner) => inner.into_iter().map(to_json).collect(),
+        Value::Bool(inner) => JsonValue::Bool(inner),
+        Value::Number(inner) => JsonValue::Number(inner),
+        Value::Object(inner) => {
+            let map = inner
+                .into_iter()
+                .map(|(k, v)| (String::from(k), to_json(v)))
+                .collect();
+
+            JsonValue::Object(map)
+        }
+        Value::String(inner) => JsonValue::String(inner),
+    }
+}
+
+pub(crate) fn from_json(value: JsonValue) -> Result<Value, Error> {
+    match value {
+        JsonValue::Null => Ok(Value::Null),
+        JsonValue::Array(data) => data.into_iter().map(from_json).collect(),
+        JsonValue::Bool(data) => Ok(Value::Bool(data)),
+        JsonValue::Number(data) => Ok(Value::Number(data)),
+        JsonValue::Object(data) => data.into_iter()
+            .map(|(k, v)| Ok((k.parse()?, from_json(v)?)))
+            .collect(),
+        JsonValue::String(data) => Ok(Value::String(data)),
+    }
+}

--- a/src/value/convert.rs
+++ b/src/value/convert.rs
@@ -7,7 +7,7 @@ use serde_json::{self, Value as JsonValue};
 use error::Error;
 use value::Value;
 
-/// Convert a `T` into a value.
+/// Convert a `T` into a `Value`.
 pub fn to_value<T>(value: T) -> Result<Value, Error>
 where
     T: Serialize,
@@ -15,7 +15,7 @@ where
     from_json(serde_json::to_value(value)?)
 }
 
-/// Interpret a value as an instance of type `T`.
+/// Interpret a `Value` as an instance of type `T`.
 pub fn from_value<T>(value: Value) -> Result<T, Error>
 where
     T: DeserializeOwned,

--- a/src/value/fields/mod.rs
+++ b/src/value/fields/mod.rs
@@ -1,3 +1,5 @@
+//! Spec-compliant member names and field paths.
+
 mod path;
 
 use std::borrow::Borrow;
@@ -12,7 +14,7 @@ use error::Error;
 
 pub use self::path::Path;
 
-/// A wrapper around `String` that enforces compliance with JSON API member names.
+/// A wrapper around `String` that enforces compliance with spec-compliant member names.
 ///
 /// # Example
 ///

--- a/src/value/fields/mod.rs
+++ b/src/value/fields/mod.rs
@@ -16,6 +16,9 @@ pub use self::path::Path;
 
 /// Represents a single member name.
 ///
+/// When an instance of `Key` is parsed, the underlying value's casing
+/// convention is converted to kebab-case.
+///
 /// # Example
 ///
 /// ```

--- a/src/value/fields/mod.rs
+++ b/src/value/fields/mod.rs
@@ -1,4 +1,4 @@
-//! Spec-compliant member names and field paths.
+//! Member names and field paths.
 
 mod path;
 
@@ -14,7 +14,7 @@ use error::Error;
 
 pub use self::path::Path;
 
-/// A wrapper around `String` that enforces compliance with spec-compliant member names.
+/// Represents a single member name.
 ///
 /// # Example
 ///

--- a/src/value/fields/path.rs
+++ b/src/value/fields/path.rs
@@ -10,7 +10,7 @@ use serde::ser::{Serialize, Serializer};
 use error::Error;
 use value::Key;
 
-/// Represent a dot-separated list of member names.
+/// Represents a dot-separated list of member names.
 ///
 /// See also: [relationship path].
 ///

--- a/src/value/fields/path.rs
+++ b/src/value/fields/path.rs
@@ -10,11 +10,10 @@ use serde::ser::{Serialize, Serializer};
 use error::Error;
 use value::Key;
 
-/// A sequence of `.` seperated JSON API [member names].
+/// Represent a dot-separated list of member names.
 ///
-/// Commonly used in query params that accept a [relationship path].
+/// See also: [relationship path].
 ///
-/// [member names]: http://jsonapi.org/format/#document-member-names
 /// [relationship path]: http://jsonapi.org/format/#fetching-includes
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Path(Vec<Key>);

--- a/src/value/key/mod.rs
+++ b/src/value/key/mod.rs
@@ -87,21 +87,18 @@ impl FromStr for Key {
         let mut dest = String::with_capacity(source.len() + 10);
         let mut chars = source.chars().peekable();
 
-        #[cfg_attr(rustfmt, rustfmt_skip)]
         match chars.next() {
-            Some(value @ '\u{002d}') |
-            Some(value @ '\u{005f}') |
-            Some(value @ '\u{0020}') => {
+            Some(value @ '_') | Some(value @ '-') | Some(value @ ' ') => {
                 bail!("cannot start with '{}'", value);
-            }
-            None => {
-                bail!("cannot be blank");
             }
             Some(value @ 'A'...'Z') => {
                 dest.push(as_lowercase(value));
             }
             Some(value) => {
                 dest.push(value);
+            }
+            None => {
+                bail!("cannot be blank");
             }
         }
 

--- a/src/value/key/mod.rs
+++ b/src/value/key/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::str::FromStr;
 
+use inflector::Inflector;
 use serde::de::{self, Deserialize, Deserializer, Visitor};
 use serde::ser::{Serialize, Serializer};
 
@@ -12,11 +13,29 @@ use error::Error;
 
 pub use self::path::Path;
 
-/// An immutable wrapper around [`String`] that enforces compliance
-/// with JSON API [Member Names].
+/// A wrapper around `String` that enforces compliance with JSON API member names.
 ///
-/// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
-/// [Member Names]: http://jsonapi.org/format/#document-member-names
+/// # Example
+///
+/// ```
+/// # extern crate json_api;
+/// #
+/// # use std::str::FromStr;
+/// #
+/// # use json_api::Error;
+/// # use json_api::value::Key;
+/// #
+/// # fn example() -> Result<(), Error> {
+/// let key = Key::from_str("someFieldName")?;
+/// assert_eq!(key, "some-field-name");
+/// #
+/// # Ok(())
+/// # }
+/// #
+/// # fn main() {
+/// # example().unwrap()
+/// # }
+/// ```
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Key(String);
 
@@ -114,7 +133,7 @@ impl FromStr for Key {
             }
         }
 
-        Ok(Key(value.to_owned()))
+        Ok(Key(value.to_kebab_case()))
     }
 }
 
@@ -127,6 +146,12 @@ impl PartialEq<String> for Key {
 impl PartialEq<str> for Key {
     fn eq(&self, rhs: &str) -> bool {
         &**self == rhs
+    }
+}
+
+impl<'a> PartialEq<&'a str> for Key {
+    fn eq(&self, rhs: &&str) -> bool {
+        &**self == *rhs
     }
 }
 

--- a/src/value/key/path.rs
+++ b/src/value/key/path.rs
@@ -167,7 +167,87 @@ impl Path {
     /// # }
     /// ```
     pub fn push(&mut self, key: Key) {
-        self.0.push(key)
+        self.0.push(key);
+    }
+
+    /// Reserves capacity for at least `additional` more keys to be inserted.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows usize.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Path;
+    /// #
+    /// # fn main() {
+    /// let mut path = Path::new();
+    ///
+    /// path.reserve(10);
+    /// assert!(path.capacity() >= 10);
+    /// # }
+    /// ```
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Reserves the minimum capacity for exactly `additional` more keys to be inserted.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity overflows usize.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Path;
+    /// #
+    /// # fn main() {
+    /// let mut path = Path::new();
+    ///
+    /// path.reserve_exact(10);
+    /// assert!(path.capacity() >= 10);
+    /// # }
+    /// ```
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.0.reserve_exact(additional);
+    }
+
+    /// Shrinks the capacity of the path as much as possible.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Error;
+    /// # use json_api::value::Path;
+    /// #
+    /// # fn example() -> Result<(), Error> {
+    /// let mut path = Path::with_capacity(10);
+    ///
+    /// path.push("authors".parse()?);
+    /// path.push("name".parse()?);
+    ///
+    /// path.shrink_to_fit();
+    /// assert!(path.capacity() >= 2);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     example().unwrap();
+    /// # }
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
     }
 
     /// Converts the `Path` into an owned byte vector.

--- a/src/value/key/path.rs
+++ b/src/value/key/path.rs
@@ -277,7 +277,7 @@ impl FromStr for Path {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        value.split('.').map(|item| item.parse()).collect()
+        value.split('.').map(Key::from_str).collect()
     }
 }
 

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -1,3 +1,8 @@
+//! A hash map implementation with consistent ordering.
+//!
+//! The types in this module are commonly used as the underlying data structure of
+//! arbitrary objects found in JSON API data.
+
 use std::hash::Hash;
 use std::iter::FromIterator;
 use std::ops::RangeFull;
@@ -6,6 +11,7 @@ use ordermap::{self, Equivalent, OrderMap};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
+/// A hash map implementation with consistent ordering.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Map<K, V>
 where
@@ -193,6 +199,7 @@ where
     }
 }
 
+/// A draining iterator over the entries of a `Map`.
 pub struct Drain<'a, K: 'a, V: 'a> {
     iter: ordermap::Drain<'a, K, V>,
 }
@@ -209,6 +216,7 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
     }
 }
 
+/// An iterator over the entries of a `Map`.
 pub struct Iter<'a, K: 'a, V: 'a> {
     iter: ordermap::Iter<'a, K, V>,
 }
@@ -249,6 +257,7 @@ impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
     }
 }
 
+/// An mutable iterator over the entries of a `Map`.
 pub struct IterMut<'a, K: 'a, V: 'a> {
     iter: ordermap::IterMut<'a, K, V>,
 }
@@ -289,6 +298,7 @@ impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
     }
 }
 
+/// An owning iterator over the entries of a `Map`.
 pub struct IntoIter<K, V> {
     iter: ordermap::IntoIter<K, V>,
 }
@@ -329,6 +339,7 @@ impl<K, V> ExactSizeIterator for IntoIter<K, V> {
     }
 }
 
+/// An iterator over the keys of a `Map`.
 pub struct Keys<'a, K: 'a, V: 'a> {
     iter: ordermap::Keys<'a, K, V>,
 }
@@ -369,6 +380,7 @@ impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
     }
 }
 
+/// An iterator over the values of a `Map`.
 pub struct Values<'a, K: 'a, V: 'a> {
     iter: ordermap::Values<'a, K, V>,
 }
@@ -409,6 +421,7 @@ impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
     }
 }
 
+/// A mutable iterator over the values of a `Map`.
 pub struct ValuesMut<'a, K: 'a, V: 'a> {
     iter: ordermap::ValuesMut<'a, K, V>,
 }

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -33,6 +33,10 @@ where
         Map { inner }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
     pub fn clear(&mut self) {
         self.inner.clear();
     }
@@ -88,6 +92,10 @@ where
         Q: Equivalent<K> + Hash,
     {
         self.inner.remove(key)
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional)
     }
 
     pub fn values(&self) -> Values<K, V> {

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -11,9 +11,11 @@ use ordermap::{self, Equivalent, OrderMap};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 
+use value::{Key, Value};
+
 /// A hash map implementation with consistent ordering.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Map<K, V>
+pub struct Map<K = Key, V = Value>
 where
     K: Eq + Hash,
 {
@@ -24,85 +26,424 @@ impl<K, V> Map<K, V>
 where
     K: Eq + Hash,
 {
+    /// Creates an empty `Map`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # fn main() {
+    /// use json_api::value::{Key, Map, Value};
+    /// let mut map = Map::<Key, Value>::new();
+    /// # }
+    /// ```
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Creates a new empty `Map`, with specified capacity.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Error;
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn example() -> Result<(), Error> {
+    /// let mut map = Map::with_capacity(2);
+    ///
+    /// map.insert("x", 1);
+    /// map.insert("y", 2);
+    ///
+    /// // The next insert will likely require reallocation...
+    /// map.insert("z", 3);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     example().unwrap();
+    /// # }
+    /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         let inner = OrderMap::with_capacity(capacity);
         Map { inner }
     }
 
+    /// Returns the number of key-value pairs the map can hold without reallocating.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::{Key, Map, Value};
+    /// #
+    /// # fn main() {
+    /// let map = Map::<Key, Value>::with_capacity(2);
+    /// assert!(map.capacity() >= 2);
+    /// # }
+    /// ```
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
 
+    /// Clears the map, removing all key-value pairs. Keeps the allocated memory
+    /// for reuse.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("x", 1);
+    /// map.clear();
+    /// assert!(map.is_empty());
+    /// # }
+    /// ```
     pub fn clear(&mut self) {
         self.inner.clear();
     }
 
-    pub fn contains_key<Q>(&self, key: &Q) -> bool
+    /// Returns true if the map contains a value for the specified key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert(1, "a");
+    /// assert_eq!(map.contains_key(&1), true);
+    /// assert_eq!(map.contains_key(&2), false);
+    /// # }
+    /// ```
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
     where
         Q: Equivalent<K> + Hash,
     {
         self.inner.contains_key(key)
     }
 
+    /// Clears the map, returning all key-value pairs as an iterator. Keeps the allocated
+    /// memory for reuse.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("x", 1);
+    /// map.insert("y", 2);
+    ///
+    /// for (key, value) in map.drain(..) {
+    ///     assert!(key == "x" || key == "y");
+    ///     assert!(value == 1 || value == 2);
+    /// }
+    ///
+    /// assert!(map.is_empty());
+    /// # }
+    /// ```
     pub fn drain(&mut self, range: RangeFull) -> Drain<K, V> {
         let iter = self.inner.drain(range);
         Drain { iter }
     }
 
-    pub fn get<Q>(&self, key: &Q) -> Option<&V>
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("x", 1);
+    ///
+    /// assert_eq!(map.get("x"), Some(&1));
+    /// assert_eq!(map.get("y"), None);
+    /// # }
+    /// ```
+    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
     where
         Q: Equivalent<K> + Hash,
     {
         self.inner.get(key)
     }
 
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If a value already existed for key, that old value is returned in `Some`;
+    /// otherwise, `None` is returned.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// assert_eq!(map.insert("x", 1), None);
+    /// assert_eq!(map.insert("x", 2), Some(1));
+    /// # }
+    /// ```
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.inner.insert(key, value)
     }
 
+    /// Return an iterator visiting all the key-value pairs of the map in the order
+    /// in which they were inserted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("a", 1);
+    /// map.insert("b", 2);
+    /// map.insert("c", 3);
+    ///
+    /// for (key, value) in map.iter() {
+    ///     println!("key: {} value: {}", key, value);
+    /// }
+    /// # }
+    /// ```
     pub fn iter(&self) -> Iter<K, V> {
         let iter = self.inner.iter();
         Iter { iter }
     }
 
+    /// Return an iterator visiting all the key-value pairs of the map in the order
+    /// in which they were inserted, with mutable references to the values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("a", 1);
+    /// map.insert("b", 2);
+    /// map.insert("c", 3);
+    ///
+    /// for (_, value) in map.iter_mut() {
+    ///     *value += 1;
+    /// }
+    ///
+    /// for (key, value) in &map {
+    ///     println!("key: {} value: {}", key, value);
+    /// }
+    /// # }
+    /// ```
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         let iter = self.inner.iter_mut();
         IterMut { iter }
     }
 
+    /// Return an iterator visiting all keys in the order in which they were inserted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("a", 1);
+    /// map.insert("b", 2);
+    /// map.insert("c", 3);
+    ///
+    /// for key in map.keys() {
+    ///     println!("{}", key);
+    /// }
+    /// # }
+    /// ```
     pub fn keys(&self) -> Keys<K, V> {
         let iter = self.inner.keys();
         Keys { iter }
     }
 
+    /// Return the number of key-value pairs in the map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    /// assert_eq!(map.len(), 0);
+    ///
+    /// map.insert("x", 1);
+    /// assert_eq!(map.len(), 1);
+    /// # }
+    /// ```
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    /// Returns true if the map contains no elements.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    /// assert!(map.is_empty());
+    ///
+    /// map.insert("x", 1);
+    /// assert!(!map.is_empty());
+    /// # }
+    /// ```
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+    /// Removes a key from the map, returning the value at the key if the key was
+    /// previously in the map.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("x", 1);
+    ///
+    /// assert_eq!(map.remove("x"), Some(1));
+    /// assert_eq!(map.remove("x"), None);
+    /// # }
+    /// ```
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
         Q: Equivalent<K> + Hash,
     {
         self.inner.remove(key)
     }
 
+
+    /// Reserves capacity for at least additional more elements to be inserted
+    /// in the `Map`. The collection may reserve more space to avoid frequent
+    /// reallocations.
+    ///
+    /// # Note
+    ///
+    /// This method has yet to be fully implemented in the [`ordermap`] crate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::{Key, Map, Value};
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::<Key, Value>::new();
+    /// map.reserve(10);
+    /// # }
+    /// ```
+    ///
+    /// [`ordermap`]: https://docs.rs/ordermap
     pub fn reserve(&mut self, additional: usize) {
-        self.inner.reserve(additional)
+        self.inner.reserve(additional);
     }
 
+    /// Return an iterator visiting all values in the order in which they were inserted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("a", 1);
+    /// map.insert("b", 2);
+    /// map.insert("c", 3);
+    ///
+    /// for value in map.values() {
+    ///     println!("{}", value);
+    /// }
+    /// # }
+    /// ```
     pub fn values(&self) -> Values<K, V> {
         let iter = self.inner.values();
         Values { iter }
     }
 
+    /// Return an iterator visiting all values mutably in the order in which they were
+    /// inserted.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::Map;
+    /// #
+    /// # fn main() {
+    /// let mut map = Map::new();
+    ///
+    /// map.insert("a", 1);
+    /// map.insert("b", 2);
+    /// map.insert("c", 3);
+    ///
+    /// for value in map.values_mut() {
+    ///     *value += 1;
+    /// }
+    ///
+    /// for value in map.values() {
+    ///     println!("{}", value);
+    /// }
+    /// # }
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
         let iter = self.inner.values_mut();
         ValuesMut { iter }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -41,7 +41,7 @@ pub enum Value {
     /// to be a valid JSON API [member name].
     ///
     /// [member name]: http://jsonapi.org/format/#document-member-names
-    Object(Map<Key, Value>),
+    Object(Map),
     /// Represents a JSON string.
     String(String),
 }
@@ -167,7 +167,7 @@ impl Value {
     /// assert_eq!(number.as_object(), None);
     /// # }
     /// ```
-    pub fn as_object(&self) -> Option<&Map<Key, Value>> {
+    pub fn as_object(&self) -> Option<&Map> {
         match *self {
             Value::Object(ref inner) => Some(inner),
             _ => None,
@@ -193,7 +193,7 @@ impl Value {
     /// assert_eq!(number.as_object_mut(), None);
     /// # }
     /// ```
-    pub fn as_object_mut(&mut self) -> Option<&mut Map<Key, Value>> {
+    pub fn as_object_mut(&mut self) -> Option<&mut Map> {
         match *self {
             Value::Object(ref mut inner) => Some(inner),
             _ => None,
@@ -662,8 +662,8 @@ impl From<String> for Value {
     }
 }
 
-impl From<Map<Key, Value>> for Value {
-    fn from(data: Map<Key, Value>) -> Self {
+impl From<Map> for Value {
+    fn from(data: Map) -> Self {
         Value::Object(data)
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -23,7 +23,7 @@ pub use self::fields::{Key, Path};
 
 /// Represents any valid JSON API value.
 ///
-/// Like [`serde_json::Value`], but with spec compliance baked into the type system.
+/// Like [`serde_json::Value`], but with spec-compliance baked into the type system.
 ///
 /// [`serde_json::Value`]: https://docs.serde.rs/serde_json/enum.Value.html
 #[derive(Clone, Debug, PartialEq)]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,4 +1,7 @@
-pub mod key;
+//! Provides types that can be used to represent valid JSON API data.
+
+mod key;
+
 pub mod map;
 pub mod set;
 
@@ -13,38 +16,107 @@ use serde_json::{self, Value as JsonValue};
 
 use error::Error;
 
-pub use http::{StatusCode, Uri};
 pub use serde_json::value::Number;
 
-pub use self::key::Key;
+pub use self::key::*;
 pub use self::map::Map;
 pub use self::set::Set;
 
+/// Represents any valid JSON API value.
+///
+/// Like [`serde_json::Value`], but with spec compliance baked into the type system.
+///
+/// [`serde_json::Value`]: https://docs.serde.rs/serde_json/enum.Value.html
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
+    /// Represents a null JSON value.
     Null,
+    /// Represents an array of values.
     Array(Vec<Value>),
+    /// Represents a boolean value (true and false).
     Bool(bool),
+    /// Represents both integers and floating point values.
     Number(Number),
+    /// Represents a JSON object as a hash table with consistent order. Keys are guarenteed
+    /// to be a valid JSON API [member name].
+    ///
+    /// [member name]: http://jsonapi.org/format/#document-member-names
     Object(Map<Key, Value>),
+    /// Represents a JSON string.
     String(String),
 }
 
 impl Value {
-    pub fn as_array(&self) -> Option<&Vec<Value>> {
+    /// Optionally get the underlying vector as a slice. Returns `None` if the
+    /// `Value` is not an array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let data = vec![true.into(), false.into()];
+    /// let array = Value::Array(data.clone());
+    /// let boolean = Value::Bool(true);
+    ///
+    /// assert_eq!(array.as_array(), Some(data.as_slice()));
+    /// assert_eq!(boolean.as_array(), None);
+    /// # }
+    /// ```
+    pub fn as_array(&self) -> Option<&[Value]> {
         match *self {
             Value::Array(ref inner) => Some(inner),
             _ => None,
         }
     }
 
-    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+    /// Optionally get the underlying vector as a mutable slice. Returns `None` if
+    /// the `Value` is not an array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let mut data = vec![true.into(), false.into()];
+    /// let mut array = Value::Array(data.clone());
+    /// let mut boolean = Value::Bool(true);
+    ///
+    /// assert_eq!(array.as_array_mut(), Some(data.as_mut_slice()));
+    /// assert_eq!(boolean.as_array_mut(), None);
+    /// # }
+    /// ```
+    pub fn as_array_mut(&mut self) -> Option<&mut [Value]> {
         match *self {
             Value::Array(ref mut inner) => Some(inner),
             _ => None,
         }
     }
 
+    /// Optionally get the inner boolean value. Returns `None` if the `Value` is
+    /// not a boolean.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let boolean = Value::Bool(true);
+    /// let number = Value::from(3.14);
+    ///
+    /// assert_eq!(boolean.as_bool(), Some(true));
+    /// assert_eq!(number.as_bool(), None);
+    /// # }
+    /// ```
     pub fn as_bool(&self) -> Option<bool> {
         match *self {
             Value::Bool(inner) => Some(inner),
@@ -52,6 +124,23 @@ impl Value {
         }
     }
 
+    /// Returns `Some(())` if the `Value` is null.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let null = Value::Null;
+    /// let text = Value::String("Hello, World!".to_owned());
+    ///
+    /// assert_eq!(null.as_null(), Some(()));
+    /// assert_eq!(text.as_null(), None);
+    /// # }
+    /// ```
     pub fn as_null(&self) -> Option<()> {
         match *self {
             Value::Null => Some(()),
@@ -59,6 +148,25 @@ impl Value {
         }
     }
 
+    /// Optionally get a reference to the inner map. Returns `None` if the `Value` is not
+    /// an object.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::{Map, Value};
+    /// #
+    /// # fn main() {
+    /// let data = Map::new();
+    /// let object = Value::Object(data.clone());
+    /// let number = Value::from(3.14);
+    ///
+    /// assert_eq!(object.as_object(), Some(&data));
+    /// assert_eq!(number.as_object(), None);
+    /// # }
+    /// ```
     pub fn as_object(&self) -> Option<&Map<Key, Value>> {
         match *self {
             Value::Object(ref inner) => Some(inner),
@@ -66,6 +174,25 @@ impl Value {
         }
     }
 
+    /// Optionally get a mutable reference to the inner map. Returns `None` if the
+    /// `Value` is not an object.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::value::{Map, Value};
+    /// #
+    /// # fn main() {
+    /// let mut data = Map::new();
+    /// let mut object = Value::Object(data.clone());
+    /// let mut number = Value::from(3.14);
+    ///
+    /// assert_eq!(object.as_object_mut(), Some(&mut data));
+    /// assert_eq!(number.as_object_mut(), None);
+    /// # }
+    /// ```
     pub fn as_object_mut(&mut self) -> Option<&mut Map<Key, Value>> {
         match *self {
             Value::Object(ref mut inner) => Some(inner),
@@ -73,6 +200,25 @@ impl Value {
         }
     }
 
+    /// Optionally get the underlying string as a string slice. Returns `None` if the
+    /// `Value` is not a string.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let data = "Hello, World!";
+    /// let string = Value::String(data.to_owned());
+    /// let number = Value::from(3.14);
+    ///
+    /// assert_eq!(string.as_str(), Some(data));
+    /// assert_eq!(number.as_str(), None);
+    /// # }
+    /// ```
     pub fn as_str(&self) -> Option<&str> {
         match *self {
             Value::String(ref inner) => Some(inner),
@@ -80,6 +226,24 @@ impl Value {
         }
     }
 
+    /// Optionally get the underlying number as an `f64`. Returns `None` if the `Value`
+    /// cannot be represented as an `f64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let number = Value::from(3.14);
+    /// let string = Value::String("Hello, World!".to_owned());
+    ///
+    /// assert_eq!(number.as_f64(), Some(3.14));
+    /// assert_eq!(string.as_f64(), None);
+    /// # }
+    /// ```
     pub fn as_f64(&self) -> Option<f64> {
         match *self {
             Value::Number(ref n) => n.as_f64(),
@@ -87,6 +251,24 @@ impl Value {
         }
     }
 
+    /// Optionally get the underlying number as an `i64`. Returns `None` if the `Value`
+    /// cannot be represented as an `i64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let integer = Value::from(10);
+    /// let float = Value::from(3.14);
+    ///
+    /// assert_eq!(integer.as_i64(), Some(10));
+    /// assert_eq!(float.as_i64(), None);
+    /// # }
+    /// ```
     pub fn as_i64(&self) -> Option<i64> {
         match *self {
             Value::Number(ref n) => n.as_i64(),
@@ -94,6 +276,24 @@ impl Value {
         }
     }
 
+    /// Optionally get the underlying number as an `u64`. Returns `None` if the `Value`
+    /// cannot be represented as an `u64`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let positive = Value::from(10);
+    /// let negative = Value::from(-10);
+    ///
+    /// assert_eq!(positive.as_u64(), Some(10));
+    /// assert_eq!(negative.as_u64(), None);
+    /// # }
+    /// ```
     pub fn as_u64(&self) -> Option<u64> {
         match *self {
             Value::Number(ref n) => n.as_u64(),
@@ -101,6 +301,31 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is an array.
+    ///
+    /// For any `Value` on which `is_array` returns true, [`as_array`] and
+    /// [`as_array_mut`] are guaranteed to return a reference to the vector
+    /// representing the array.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let mut value = Value::from(vec![1, 2, 3]);
+    ///
+    /// assert!(value.is_array());
+    ///
+    /// value.as_array().unwrap();
+    /// value.as_array_mut().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_array`]: #method.as_array
+    /// [`as_array_mut`]: #method.as_array_mut
     pub fn is_array(&self) -> bool {
         match *self {
             Value::Array(_) => true,
@@ -108,13 +333,55 @@ impl Value {
         }
     }
 
-    pub fn is_bool(&self) -> bool {
+    /// Returns true if the `Value` is a boolean.
+    ///
+    /// For any `Value` on which `is_boolean` returns true, [`as_bool`] is guaranteed
+    /// to return the boolean value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let value = Value::Bool(true);
+    ///
+    /// assert!(value.is_boolean());
+    /// value.as_bool().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_bool`]: #method.as_bool
+    pub fn is_boolean(&self) -> bool {
         match *self {
             Value::Bool(_) => true,
             _ => false,
         }
     }
 
+    /// Returns true if the `Value` is null.
+    ///
+    /// For any `Value` on which `is_null` returns true, [`as_null`] is guaranteed
+    /// to return `Some(())`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let value = Value::Null;
+    ///
+    /// assert!(value.is_null());
+    /// value.as_null().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_null`]: #method.as_null
     pub fn is_null(&self) -> bool {
         match *self {
             Value::Null => true,
@@ -122,6 +389,19 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a number.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// assert!(Value::from(3.14).is_number());
+    /// # }
+    /// ```
     pub fn is_number(&self) -> bool {
         match *self {
             Value::Number(_) => true,
@@ -129,6 +409,31 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is an object.
+    ///
+    /// For any `Value` on which `is_array` returns true, [`as_object`] and
+    /// [`as_object_mut`] are guaranteed to return a reference to the map
+    /// representing the object.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let mut value = Value::Object(Default::default());
+    ///
+    /// assert!(value.is_object());
+    ///
+    /// value.as_object().unwrap();
+    /// value.as_object_mut().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_object`]: #method.as_object
+    /// [`as_object_mut`]: #method.as_object_mut
     pub fn is_object(&self) -> bool {
         match *self {
             Value::Object(_) => true,
@@ -136,6 +441,27 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a string.
+    ///
+    /// For any `Value` on which `is_string` returns true, [`as_str`] is guaranteed
+    /// to return the string slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let value = Value::String("Hello, world!".to_owned());
+    ///
+    /// assert!(value.is_string());
+    /// value.as_str().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_str`]: #method.as_str
     pub fn is_string(&self) -> bool {
         match *self {
             Value::String(_) => true,
@@ -143,6 +469,32 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is a number that can be represented as an `f64`.
+    ///
+    /// For any `Value` on which `is_f64` returns true, [`as_f64`] is guaranteed to
+    /// return the floating point value.
+    ///
+    /// Currently this function returns true if and only if both [`is_i64`] and
+    /// [`is_u64`] return false. This behavior is not a guarantee in the future.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let value = Value::from(3.14);
+    ///
+    /// assert!(value.is_f64());
+    /// value.as_f64().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_f64`]: #method.as_f64
+    /// [`is_i64`]: #method.is_i64
+    /// [`is_u64`]: #method.is_u64
     pub fn is_f64(&self) -> bool {
         match *self {
             Value::Number(ref n) => n.is_f64(),
@@ -150,6 +502,31 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is an integer between `i64::MIN` and `i64::MAX`.
+    ///
+    /// For any Value on which `is_i64` returns true, [`as_i64`] is guaranteed to return
+    /// the integer value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let pos = Value::from(3);
+    /// let neg = Value::from(-3);
+    ///
+    /// assert!(pos.is_i64());
+    /// assert!(neg.is_i64());
+    ///
+    /// pos.as_i64().unwrap();
+    /// neg.as_i64().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_i64`]: #method.as_i64
     pub fn is_i64(&self) -> bool {
         match *self {
             Value::Number(ref n) => n.is_i64(),
@@ -157,11 +534,59 @@ impl Value {
         }
     }
 
+    /// Returns true if the `Value` is an integer between `0` and `u64::MAX`.
+    ///
+    /// For any Value on which `is_u64` returns true, [`as_u64`] is guaranteed to return
+    /// the integer value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate json_api;
+    /// #
+    /// # use json_api::Value;
+    /// #
+    /// # fn main() {
+    /// let value = Value::from(3);
+    ///
+    /// assert!(value.is_u64());
+    /// value.as_u64().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// [`as_u64`]: #method.as_u64
     pub fn is_u64(&self) -> bool {
         match *self {
             Value::Number(ref n) => n.is_u64(),
             _ => false,
         }
+    }
+}
+
+/// Returns the `Value::Null`. This allows for better composition with `Option` types.
+///
+/// # Example
+///
+/// ```
+/// # extern crate json_api;
+/// #
+/// # use json_api::Value;
+/// #
+/// # fn main() {
+/// const MSG: &'static str = "Hello, World!";
+///
+/// let opt = None;
+/// let value = opt.map(Value::String).unwrap_or_default();
+/// assert_eq!(value, Value::Null);
+///
+/// let opt = Some(MSG.to_owned());
+/// let value = opt.map(Value::String).unwrap_or_default();
+/// assert_eq!(value, Value::String(MSG.to_owned()));
+/// # }
+/// ```
+impl Default for Value {
+    fn default() -> Self {
+        Value::Null
     }
 }
 
@@ -179,7 +604,7 @@ impl From<f32> for Value {
 
 impl From<f64> for Value {
     fn from(n: f64) -> Self {
-        Number::from_f64(n).map_or(Value::Null, Value::Number)
+        Number::from_f64(n).map(Value::Number).unwrap_or_default()
     }
 }
 
@@ -248,7 +673,7 @@ where
     T: Into<Value>,
 {
     fn from(data: Option<T>) -> Self {
-        data.map_or(Value::Null, T::into)
+        data.map(T::into).unwrap_or_default()
     }
 }
 
@@ -409,16 +834,16 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::Bool(value))
             }
 
+            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
+                Ok(Value::from(value))
+            }
+
             fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
                 Ok(Value::Number(value.into()))
             }
 
             fn visit_u64<E>(self, value: u64) -> Result<Value, E> {
                 Ok(Value::Number(value.into()))
-            }
-
-            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
-                Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
             }
 
             fn visit_str<E: Error>(self, value: &str) -> Result<Value, E> {
@@ -494,6 +919,7 @@ impl Serialize for Value {
     }
 }
 
+/// Interpret a JSON API value as an instance of type `T`.
 pub fn to_value<T>(value: T) -> Result<Value, Error>
 where
     T: Serialize,
@@ -501,6 +927,7 @@ where
     from_json(serde_json::to_value(value)?)
 }
 
+/// Convert a `T` into a JSON API value.
 pub fn from_value<T>(value: Value) -> Result<T, Error>
 where
     T: DeserializeOwned,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -598,7 +598,7 @@ impl From<bool> for Value {
 
 impl From<f32> for Value {
     fn from(n: f32) -> Self {
-        From::from(n as f64)
+        Value::from(f64::from(n))
     }
 }
 
@@ -610,19 +610,19 @@ impl From<f64> for Value {
 
 impl From<i8> for Value {
     fn from(n: i8) -> Self {
-        From::from(n as i64)
+        Value::from(i64::from(n))
     }
 }
 
 impl From<i16> for Value {
     fn from(n: i16) -> Self {
-        From::from(n as i64)
+        Value::from(i64::from(n))
     }
 }
 
 impl From<i32> for Value {
     fn from(n: i32) -> Self {
-        From::from(n as i64)
+        Value::from(i64::from(n))
     }
 }
 
@@ -634,19 +634,19 @@ impl From<i64> for Value {
 
 impl From<u8> for Value {
     fn from(n: u8) -> Self {
-        From::from(n as u64)
+        Value::from(u64::from(n))
     }
 }
 
 impl From<u16> for Value {
     fn from(n: u16) -> Self {
-        From::from(n as u64)
+        Value::from(u64::from(n))
     }
 }
 
 impl From<u32> for Value {
     fn from(n: u32) -> Self {
-        From::from(n as u64)
+        Value::from(u64::from(n))
     }
 }
 
@@ -738,73 +738,73 @@ impl PartialEq<bool> for Value {
 
 impl PartialEq<f32> for Value {
     fn eq(&self, rhs: &f32) -> bool {
-        self.as_f64().map_or(false, |lhs| lhs == (*rhs as f64))
+        *self == f64::from(*rhs)
     }
 }
 
 impl PartialEq<f64> for Value {
     fn eq(&self, rhs: &f64) -> bool {
-        self.as_f64().map_or(false, |lhs| lhs == (*rhs as f64))
+        self.as_f64().map_or(false, |lhs| lhs == *rhs)
     }
 }
 
 impl PartialEq<i8> for Value {
     fn eq(&self, rhs: &i8) -> bool {
-        self.as_i64().map_or(false, |lhs| lhs == (*rhs as i64))
+        *self == i64::from(*rhs)
     }
 }
 
 impl PartialEq<i16> for Value {
     fn eq(&self, rhs: &i16) -> bool {
-        self.as_i64().map_or(false, |lhs| lhs == (*rhs as i64))
+        *self == i64::from(*rhs)
     }
 }
 
 impl PartialEq<i32> for Value {
     fn eq(&self, rhs: &i32) -> bool {
-        self.as_i64().map_or(false, |lhs| lhs == (*rhs as i64))
+        *self == i64::from(*rhs)
     }
 }
 
 impl PartialEq<i64> for Value {
     fn eq(&self, rhs: &i64) -> bool {
-        self.as_i64().map_or(false, |lhs| lhs == (*rhs as i64))
+        self.as_i64().map_or(false, |lhs| lhs == *rhs)
     }
 }
 
 impl PartialEq<isize> for Value {
     fn eq(&self, rhs: &isize) -> bool {
-        self.as_i64().map_or(false, |lhs| lhs == (*rhs as i64))
+        *self == (*rhs as i64)
     }
 }
 
 impl PartialEq<u8> for Value {
     fn eq(&self, rhs: &u8) -> bool {
-        self.as_u64().map_or(false, |lhs| lhs == (*rhs as u64))
+        *self == u64::from(*rhs)
     }
 }
 
 impl PartialEq<u16> for Value {
     fn eq(&self, rhs: &u16) -> bool {
-        self.as_u64().map_or(false, |lhs| lhs == (*rhs as u64))
+        *self == u64::from(*rhs)
     }
 }
 
 impl PartialEq<u32> for Value {
     fn eq(&self, rhs: &u32) -> bool {
-        self.as_u64().map_or(false, |lhs| lhs == (*rhs as u64))
+        *self == u64::from(*rhs)
     }
 }
 
 impl PartialEq<u64> for Value {
     fn eq(&self, rhs: &u64) -> bool {
-        self.as_u64().map_or(false, |lhs| lhs == (*rhs as u64))
+        self.as_u64().map_or(false, |lhs| lhs == *rhs)
     }
 }
 
 impl PartialEq<usize> for Value {
     fn eq(&self, rhs: &usize) -> bool {
-        self.as_u64().map_or(false, |lhs| lhs == (*rhs as u64))
+        *self == (*rhs as u64)
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -19,6 +19,7 @@ pub use serde_json::value::Number;
 
 pub use self::collections::{Map, Set};
 pub use self::convert::{from_value, to_value};
+#[doc(no_inline)]
 pub use self::fields::{Key, Path};
 
 /// Represents any valid JSON API value.

--- a/src/value/set.rs
+++ b/src/value/set.rs
@@ -11,11 +11,12 @@ use ordermap::Equivalent;
 use serde::de::{Deserialize, Deserializer, Visitor};
 use serde::ser::{Serialize, Serializer};
 
+use value::Key;
 use value::map::{self, Keys, Map};
 
 /// A hash set implemented as a `Map` where the value is `()`.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Set<T: Eq + Hash> {
+pub struct Set<T: Eq + Hash = Key> {
     inner: Map<T, ()>,
 }
 
@@ -37,7 +38,7 @@ impl<T: Eq + Hash> Set<T> {
         self.inner.clear();
     }
 
-    pub fn contains<Q>(&self, key: &Q) -> bool
+    pub fn contains<Q: ?Sized>(&self, key: &Q) -> bool
     where
         Q: Equivalent<T> + Hash,
     {
@@ -66,7 +67,7 @@ impl<T: Eq + Hash> Set<T> {
         self.inner.len()
     }
 
-    pub fn remove<Q>(&mut self, key: &Q) -> bool
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> bool
     where
         Q: Equivalent<T> + Hash,
     {

--- a/src/value/set.rs
+++ b/src/value/set.rs
@@ -29,6 +29,10 @@ impl<T: Eq + Hash> Set<T> {
         Set { inner }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
     pub fn clear(&mut self) {
         self.inner.clear();
     }
@@ -67,6 +71,10 @@ impl<T: Eq + Hash> Set<T> {
         Q: Equivalent<T> + Hash,
     {
         self.inner.remove(key).is_some()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.inner.reserve(additional)
     }
 }
 

--- a/src/value/set.rs
+++ b/src/value/set.rs
@@ -1,3 +1,5 @@
+//! A hash set implemented as a `Map` where the value is `()`.
+
 use std::fmt::{self, Display, Formatter};
 use std::hash::Hash;
 use std::iter::FromIterator;
@@ -11,6 +13,7 @@ use serde::ser::{Serialize, Serializer};
 
 use value::map::{self, Keys, Map};
 
+/// A hash set implemented as a `Map` where the value is `()`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Set<T: Eq + Hash> {
     inner: Map<T, ()>,
@@ -193,6 +196,7 @@ impl<T: Display + Eq + Hash> Serialize for Set<T> {
     }
 }
 
+/// A draining iterator over the items of a `Set`.
 pub struct Drain<'a, T: 'a> {
     iter: map::Drain<'a, T, ()>,
 }
@@ -209,6 +213,7 @@ impl<'a, T> Iterator for Drain<'a, T> {
     }
 }
 
+/// An iterator over the items of a `Set`.
 pub struct Iter<'a, T: 'a> {
     iter: Keys<'a, T, ()>,
 }
@@ -249,6 +254,7 @@ impl<'a, T> ExactSizeIterator for Iter<'a, T> {
     }
 }
 
+/// An owning iterator over the items of a `Set`.
 pub struct IntoIter<T> {
     iter: map::IntoIter<T, ()>,
 }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -87,8 +87,7 @@ fn to_mapping() -> Result<Mapping, Error> {
     let mapping = from_mapping()?
         .into_iter()
         .map(|(key, value)| match key {
-            "page%5Bnumber%5D=0" => ("", value),
-            "page%5Bnumber%5D=1" => ("", value),
+            "page%5Bnumber%5D=0" | "page%5Bnumber%5D=1" => ("", value),
             _ => (key, value),
         })
         .collect();


### PR DESCRIPTION
### Notable Changes:

- Adds documentation with examples/tests for public APIs
- Adds missing methods and trait implementations where necessary
- Moves the `map`, and `set` module within a new `collections` module at the root of `value`
- Reexports `ordermap::Equivalent` from `collections`
- Removes `http` reexports from the `value` module
- Reexports all of `http` from the crate root
