### PR TITLE
feat: basic error logging when running in a non-prod env 

### DIFF
--- a/rocket/Cargo.toml
+++ b/rocket/Cargo.toml
@@ -23,10 +23,12 @@ repository = "zacharygolba/json-api-rs"
 repository = "zacharygolba/json-api-rs"
 
 [dependencies]
+lazy_static = "0.2.11"
 rocket = "0.3"
 rocket_contrib = "0.3"
 serde = "1.0"
 serde_json = "1.0"
+thread_local = "0.3.4"
 
 [dependencies.json-api]
 path = "../"

--- a/rocket/Cargo.toml
+++ b/rocket/Cargo.toml
@@ -28,7 +28,6 @@ rocket = "0.3"
 rocket_contrib = "0.3"
 serde = "1.0"
 serde_json = "1.0"
-thread_local = "0.3.4"
 
 [dependencies.json-api]
 path = "../"

--- a/rocket/src/error.rs
+++ b/rocket/src/error.rs
@@ -10,6 +10,7 @@ macro_rules! catchers {
             _: RocketError,
             _req: &Request,
         ) -> Result<Response<'static>, Status> {
+            use json_api;
             use json_api::doc::{Document, ErrorObject, Object};
 
             let doc: Document<Object> = Document::Err {
@@ -24,10 +25,13 @@ macro_rules! catchers {
                 meta: Default::default(),
             };
 
-            response::with_body(doc).map(move |mut resp| {
-                resp.set_raw_status($status.as_u16(), "");
-                resp
-            })
+            json_api::to_vec(doc, None)
+                .map(response::with_body)
+                .or_else(response::fail)
+                .map(|mut resp| {
+                    resp.set_raw_status($status.as_u16(), "");
+                    resp
+                })
         })*
 
         pub fn catchers() -> Vec<Catcher> {

--- a/rocket/src/lib.rs
+++ b/rocket/src/lib.rs
@@ -1,10 +1,27 @@
 extern crate json_api;
+#[macro_use]
+extern crate lazy_static;
 extern crate rocket;
 extern crate serde;
 extern crate serde_json;
 
 mod error;
 mod fairing;
+
+mod config {
+    use std::env;
+
+    use rocket::config::Environment;
+
+    lazy_static!{
+        pub static ref ROCKET_ENV: Environment = {
+            match env::var("ROCKET_ENV").ok() {
+                Some(value) => value.parse().unwrap_or(Environment::Development),
+                None => Environment::Development,
+            }
+        };
+    }
+}
 
 pub mod request;
 pub mod response;

--- a/rocket/src/request.rs
+++ b/rocket/src/request.rs
@@ -120,6 +120,20 @@ impl Query {
     }
 }
 
+impl Deref for Query {
+    type Target = JsonApiQuery;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for Query {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
 impl<'a, 'r> FromRequest<'a, 'r> for Query {
     type Error = Error;
 

--- a/rocket/src/response.rs
+++ b/rocket/src/response.rs
@@ -148,6 +148,7 @@ pub(crate) fn with_body(body: Vec<u8>) -> Response<'static> {
         .finalize()
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 pub(crate) fn fail(e: Error) -> Result<Response<'static>, Status> {
     use config::ROCKET_ENV;
 

--- a/src/doc/mod.rs
+++ b/src/doc/mod.rs
@@ -14,8 +14,11 @@ use std::iter::FromIterator;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
+use error::Error;
+use query::Query;
 use sealed::Sealed;
 use value::{Key, Map, Set, Value};
+use view::Render;
 
 pub use self::convert::*;
 pub use self::error::{ErrorObject, ErrorSource};
@@ -109,6 +112,12 @@ impl<T: PrimaryData> Document<T> {
             Document::Ok { .. } => true,
             Document::Err { .. } => false,
         }
+    }
+}
+
+impl<T: PrimaryData> Render<T> for Document<T> {
+    fn render(self, _: Option<&Query>) -> Result<Document<T>, Error> {
+        Ok(self)
     }
 }
 


### PR DESCRIPTION
Adds basic error logging for the `json-api-rocket` crate.