### PR TITLE
fix: from_* impl is broken for orphaned idents

### DIFF
--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -148,7 +148,7 @@ impl PrimaryData for Identifier {
         incl.into_iter()
             .find(|item| self == **item)
             .map(|item| item.clone().flatten(incl))
-            .unwrap_or_else(|| self.id.into())
+            .unwrap_or_else(|| self.id.clone().into())
     }
 }
 

--- a/src/doc/ident.rs
+++ b/src/doc/ident.rs
@@ -148,7 +148,7 @@ impl PrimaryData for Identifier {
         incl.into_iter()
             .find(|item| self == **item)
             .map(|item| item.clone().flatten(incl))
-            .unwrap_or_default()
+            .unwrap_or_else(|| self.id.into())
     }
 }
 


### PR DESCRIPTION
In the event that a matching included object cannot be resolved for an ident, it should flatten into the value of it's id. This prevents errors when resolving an included relationship for a `POST` or `PATCH` request.