### PR TITLE
fix: rustfmt is not running in ci builds

### DIFF
--- a/rocket/src/fairing.rs
+++ b/rocket/src/fairing.rs
@@ -1,5 +1,5 @@
-use rocket::fairing::{Fairing, Info, Kind};
 use rocket::Rocket;
+use rocket::fairing::{Fairing, Info, Kind};
 
 use error;
 

--- a/rocket/src/response.rs
+++ b/rocket/src/response.rs
@@ -4,10 +4,10 @@ use std::ops::{Deref, DerefMut};
 
 use json_api::doc::Object;
 use json_api::{self, Error, Resource};
+use rocket::Outcome;
 use rocket::http::Status;
 use rocket::request::{FromRequest, Request};
 use rocket::response::{Responder, Response};
-use rocket::Outcome;
 
 use request::Query;
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ fi
 run cargo update
 run cargo build
 
-run_plugin stable fmt -- --check
+run_plugin stable fmt -- --write-mode diff
 
 if [ $DEFAULT_TOOLCHAIN == $NIGHTLY ]; then
   run_plugin $NIGHTLY clippy --all

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ fi
 run cargo update
 run cargo build
 
-run_plugin fmt -- --check
+run_plugin stable fmt -- --check
 
 if [ $DEFAULT_TOOLCHAIN == $NIGHTLY ]; then
   run_plugin $NIGHTLY clippy --all

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,7 @@ echo ""
 
 run rustup install stable beta $NIGHTLY
 run rustup default $DEFAULT_TOOLCHAIN
-run rustup component add rustfmt-preview
+run rustup component add rustfmt-preview --toolchain stable
 
 if ! has_plugin clippy; then
   run cargo +$NIGHTLY install clippy --vers 0.0.204

--- a/src/doc/convert.rs
+++ b/src/doc/convert.rs
@@ -22,8 +22,7 @@ where
                     Some(item) => item.flatten(&included),
                     None => Value::Null,
                 },
-                Data::Collection(data) => data
-                    .into_iter()
+                Data::Collection(data) => data.into_iter()
                     .map(|item| item.flatten(&included))
                     .collect(),
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,8 @@ pub use doc::Document;
 #[doc(inline)]
 pub use doc::{from_doc, from_reader, from_slice, from_str};
 #[doc(inline)]
-pub use doc::{
-    to_doc, to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty,
-};
+pub use doc::{to_doc, to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer,
+              to_writer_pretty};
 #[doc(inline)]
 pub use error::Error;
 pub use resource::Resource;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -3,8 +3,8 @@ use std::mem;
 use doc::{Data, Document, Identifier, Object};
 use error::Error;
 use query::Query;
-use value::fields::Key;
 use value::Set;
+use value::fields::Key;
 use view::{Context, Render};
 
 /// A trait indicating that the given type can be represented as a resource.

--- a/src/value/collections/set.rs
+++ b/src/value/collections/set.rs
@@ -12,9 +12,9 @@ use serde::ser::{Serialize, SerializeSeq, Serializer};
 
 use error::Error;
 use sealed::Sealed;
-use value::collections::map::{self, Keys, Map};
-use value::collections::Equivalent;
 use value::Key;
+use value::collections::Equivalent;
+use value::collections::map::{self, Keys, Map};
 
 /// A hash set implemented as a `Map` where the value is `()`.
 #[derive(Clone, Eq, PartialEq)]

--- a/src/value/convert.rs
+++ b/src/value/convert.rs
@@ -47,8 +47,7 @@ pub(crate) fn from_json(value: JsonValue) -> Result<Value, Error> {
         JsonValue::Array(data) => data.into_iter().map(from_json).collect(),
         JsonValue::Bool(data) => Ok(Value::Bool(data)),
         JsonValue::Number(data) => Ok(Value::Number(data)),
-        JsonValue::Object(data) => data
-            .into_iter()
+        JsonValue::Object(data) => data.into_iter()
             .map(|(k, v)| Ok((k.parse()?, from_json(v)?)))
             .collect(),
         JsonValue::String(data) => Ok(Value::String(data)),

--- a/src/view/context.rs
+++ b/src/view/context.rs
@@ -1,7 +1,7 @@
 use doc::Object;
 use query::Query;
-use value::fields::{Key, Path, Segment};
 use value::Set;
+use value::fields::{Key, Path, Segment};
 
 /// A data structure containing render context that can be "forked" and passed
 /// to a child context.

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -2,8 +2,8 @@ extern crate json_api;
 #[macro_use]
 extern crate ordermap;
 
-use json_api::query::{self, Direction, Query};
 use json_api::Error;
+use json_api::query::{self, Direction, Query};
 use ordermap::OrderMap;
 
 type Mapping = OrderMap<&'static str, Query>;


### PR DESCRIPTION
The command was missing a toolchain argument.